### PR TITLE
Removed docstrings from some methods to avoid publishing them.

### DIFF
--- a/Products/CMFCore/CHANGES.txt
+++ b/Products/CMFCore/CHANGES.txt
@@ -4,7 +4,8 @@ Products.CMFCore Changelog
 2.2.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Removed docstrings from some methods to avoid publishing them.  From
+  Products.PloneHotfix20160419.  [maurits]
 
 
 2.2.10 (2015-09-11)

--- a/Products/CMFCore/PortalFolder.py
+++ b/Products/CMFCore/PortalFolder.py
@@ -86,8 +86,7 @@ class PortalFolderBase(DynamicType, OpaqueItemManager, Folder):
 
     security.declareProtected(View, 'Type')
     def Type(self):
-        """ Dublin Core Type element - resource type.
-        """
+        # Dublin Core Type element - resource type.
         ti = self.getTypeInfo()
         return ti is not None and ti.Title() or 'Unknown'
 


### PR DESCRIPTION
From Products.PloneHotfix20160419.

We could remove docstrings from lots more methods, but this is the one from last month's hotfix.
No big deal, really, but it is nobody's business what `Type` a content type is.