### PR TITLE
Fixed TypeError for too old style exception in test. [master]

### DIFF
--- a/Products/CMFCore/tests/test_FSMetadata.py
+++ b/Products/CMFCore/tests/test_FSMetadata.py
@@ -30,7 +30,7 @@ class FSMetadata(FSDVTest, MetadataChecker):
         # Test proxy roles on the object
         for role in roles:
             if not obj.manage_haveProxy(role):
-                raise 'Object does not have the "%s" role' % role
+                raise ValueError('Object does not have the "%s" role' % role)
 
     def test_basicPermissions(self):
         # Test basic FS permissions


### PR DESCRIPTION
TypeError: exceptions must be old-style classes or derived from BaseException, not str