### PR TITLE
Don't fail on catalog inconsistency when doing a reindexObjectSecurity

### DIFF
--- a/Products/CMFCore/CHANGES.txt
+++ b/Products/CMFCore/CHANGES.txt
@@ -18,6 +18,8 @@ Products.CMFCore Changelog
 - Make sure RegistrationTool.addMember is not published
   [vangheem]
 
+- Don't fail on catalog inconsistency when doing `reindexObjectSecurity`
+  [tomgross]
 
 2.2.9 (2015-02-20)
 ------------------

--- a/Products/CMFCore/CMFCatalogAware.py
+++ b/Products/CMFCore/CMFCatalogAware.py
@@ -105,7 +105,11 @@ class CatalogAware(Base):
             if brain_path == path and skip_self:
                 continue
             # Get the object
-            ob = brain._unrestrictedGetObject()
+            try:
+                ob = brain._unrestrictedGetObject()
+            except (AttributeError, KeyError):
+                # don't fail on catalog inconsistency
+                continue
             if ob is None:
                 # BBB: Ignore old references to deleted objects.
                 # Can happen only when using


### PR DESCRIPTION
Same content as #6 but for 2.2 branch.