### PR TITLE
Configure Travis CI integration for the 2.2 branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+sudo: false
+python:
+    - "2.7"
+install:
+    - python bootstrap.py
+    - bin/buildout
+script:
+    - bin/test -v
+notifications:
+    email: false
+cache:
+  pip: true
+  directories:
+    - eggs/


### PR DESCRIPTION
I only added the configuration as the tests pass locally.
Later on the versions of setuptools and zc.buildout might be upgraded.