### PR TITLE
Minor cleanup

### DIFF
--- a/Products/CMFCore/CHANGES.txt
+++ b/Products/CMFCore/CHANGES.txt
@@ -23,6 +23,9 @@ Products.CMFCore Changelog
   Part of PLIP 1343: https://github.com/plone/Products.CMFPlone/issues/1343
   [gforcada]
 
+- Remove zope.app.publication dependency.
+  [gforcada]
+
 2.2.10 (2015-09-11)
 -------------------
 

--- a/Products/CMFCore/CHANGES.txt
+++ b/Products/CMFCore/CHANGES.txt
@@ -26,6 +26,9 @@ Products.CMFCore Changelog
 - Remove zope.app.publication dependency.
   [gforcada]
 
+- Remove eggtestinfo dependency.
+  [gforcada]
+
 2.2.10 (2015-09-11)
 -------------------
 

--- a/Products/CMFCore/PortalObject.py
+++ b/Products/CMFCore/PortalObject.py
@@ -18,12 +18,7 @@ from Products.Five.component.interfaces import IObjectManagerSite
 from zope.component.interfaces import ComponentLookupError
 from zope.event import notify
 from zope.interface import implements
-try:
-    from zope.traversing.interfaces import BeforeTraverseEvent
-except ImportError:
-    # BBB: for Zope < 2.13
-    from zope.app.publication.zopepublication import BeforeTraverseEvent
-
+from zope.traversing.interfaces import BeforeTraverseEvent
 from Products.CMFCore.interfaces import ISiteRoot
 from Products.CMFCore.permissions import AddPortalMember
 from Products.CMFCore.permissions import SetOwnPassword

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(name='Products.%s' % NAME,
           'five.localsitemanager',
           'Products.GenericSetup',
           'Products.ZSQLMethods',
-          'zope.app.publication',
           ],
       tests_require=[
           'zope.testing >= 3.7.0',

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,6 @@ setup(name='Products.%s' % NAME,
       include_package_data=True,
       namespace_packages=['Products'],
       zip_safe=False,
-      setup_requires=['eggtestinfo',
-                     ],
       install_requires=[
           'setuptools',
           'Zope2 > 2.12.8',


### PR DESCRIPTION
This pull request does two minimal things:

- remove a deprecated import (zope.app.publication)
- removes eggtestinfo from test_requires