### PR TITLE
Make imports of 'webdav' conditional.

### DIFF
--- a/Products/CMFCore/CHANGES.txt
+++ b/Products/CMFCore/CHANGES.txt
@@ -4,6 +4,16 @@ Products.CMFCore Changelog
 2.3.1 (unreleased)
 ------------------
 
+- Make imports of 'webdav' conditional.
+
+  Zope4 moves WebDAV support out to the newly-optional ``ZServer`` dependency.
+  This PR aims to make CMFCore work there whether or not ``ZServer`` is
+  installed.
+
+  It adds a ``webdav`` extra to allow downstream projects to signal explicitly
+  that they need that support.
+  [tseaver]
+
 - Make sure RegistrationTool.addMember is not published
   [vangheem]
 

--- a/Products/CMFCore/exceptions.py
+++ b/Products/CMFCore/exceptions.py
@@ -16,7 +16,11 @@
 from AccessControl import ModuleSecurityInfo
 from AccessControl import Unauthorized as AccessControl_Unauthorized
 from OFS.CopySupport import CopyError
-from webdav.Lockable import ResourceLockedError
+try:
+    from webdav.Lockable import ResourceLockedError
+except ImportError:
+    class ResourceLockedError(Exception):
+        pass
 from zExceptions import BadRequest
 from zExceptions import NotFound
 from zExceptions import Unauthorized as zExceptions_Unauthorized

--- a/Products/CMFCore/testing.py
+++ b/Products/CMFCore/testing.py
@@ -30,16 +30,25 @@ from Products.GenericSetup.utils import BodyAdapterBase
 
 class ConformsToFolder:
 
-    def test_folder_interfaces(self):
-        from webdav.interfaces import IWriteLock
-        from Products.CMFCore.interfaces import IDynamicType
-        from Products.CMFCore.interfaces import IFolderish
-        from Products.CMFCore.interfaces import IMutableMinimalDublinCore
+    def test_conforms_to_IWritelock(self):
+        try:
+            from webdav.interfaces import IWriteLock
+        except ImportError:
+            self.skipTest("'webdav' not importable.")
+        else:
+            verifyClass(IWriteLock, self._getTargetClass())
 
+    def test_conforms_to_IDynamicType(self):
+        from Products.CMFCore.interfaces import IDynamicType
         verifyClass(IDynamicType, self._getTargetClass())
+
+    def test_conforms_to_IFolderish(self):
+        from Products.CMFCore.interfaces import IFolderish
         verifyClass(IFolderish, self._getTargetClass())
+
+    def test_conforms_to_IMutableDublinCore(self):
+        from Products.CMFCore.interfaces import IMutableMinimalDublinCore
         verifyClass(IMutableMinimalDublinCore, self._getTargetClass())
-        verifyClass(IWriteLock, self._getTargetClass())
 
     def test_folder_extra_interfaces(self):
         # in the long run this interface will become deprecated

--- a/Products/CMFCore/tests/test_TypesTool.py
+++ b/Products/CMFCore/tests/test_TypesTool.py
@@ -101,7 +101,10 @@ class TypesToolFunctionalTests(SecurityTest):
         # all typeinfo's returned by allMetaTypes can be traversed to.
         from Acquisition import aq_base
         from Products.CMFCore.interfaces import ITypeInformation
-        from webdav.NullResource import NullResource
+        try:
+            from webdav.NullResource import NullResource
+        except ImportError:
+            NullResource = object()
         site = self._makeSite().__of__(self.app)
         tool = self._makeOne().__of__(site)
         meta_types = {}

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -4,6 +4,7 @@ extends =
 develop = .
 parts =
     test
+    test_w_webdav
     zopepy
     sphinx
 
@@ -16,7 +17,13 @@ zc.buildout = 2.5.3
 
 [test]
 recipe = zc.recipe.testrunner
-eggs = Products.CMFCore
+eggs =
+    Products.CMFCore
+
+[test_w_webdav]
+recipe = zc.recipe.testrunner
+eggs =
+    Products.CMFCore[webdav]
 
 
 [zopepy]

--- a/setup.py
+++ b/setup.py
@@ -60,10 +60,10 @@ setup(name='Products.%s' % NAME,
           'zope.testing >= 3.7.0',
           'Products.StandardCacheManagers',
           ],
-      extras_require=dict(
-        test=[
-          'Products.StandardCacheManagers',
-          ]),
+      extras_require={
+          'test': ['Products.StandardCacheManagers'],
+          'webdav': ['ZServer'],
+          },
       test_loader='zope.testing.testrunner.eggsupport:SkipLayers',
       test_suite='Products.%s' % NAME,
       entry_points="""


### PR DESCRIPTION
Zope4 moves WebDAV support out to the newly-optional 'ZServer' dependency. This PR aims to make CMFCore work there whether or not 'ZServer' is installed.

It adds a 'webdav' extra to allow downstream projects to signal explicitly that they need that support.