### PR TITLE
Do not autogenerate `string:${portal_url}/` for `icon_expr`.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,9 @@ Products.CMFCore Changelog
 - remove dependency on ``five.globalrequest``, its functionality
   is provided by ``zope.globalrequest``.
 
+- Do not autogenerate `string:${portal_url}/`, when no input for
+  `content_icon` was provided.
+  [pgrunewald]
 
 2.4.0b2 (2017-05-05)
 --------------------

--- a/Products/CMFCore/exportimport/tests/test_typeinfo.py
+++ b/Products/CMFCore/exportimport/tests/test_typeinfo.py
@@ -168,6 +168,16 @@ _NORMAL_TOOL_EXPORT = """\
 </object>
 """
 
+_EXTENDED_TOOL_EXPORT = """\
+<?xml version="1.0"?>
+<object name="portal_types" meta_type="CMF Types Tool">
+ <property name="title"/>
+ <object name="foo" meta_type="Factory-based Type Information"/>
+ <object name="bar" meta_type="Scriptable Type Information"/>
+ <object name="baz" meta_type="Scriptable Type Information"/>
+</object>
+"""
+
 _FILENAME_EXPORT = """\
 <?xml version="1.0"?>
 <object name="portal_types" meta_type="CMF Types Tool">
@@ -322,24 +332,24 @@ _BAZ_CMF21_IMPORT = """\
  <property name="content_meta_type">Baz Thing</property>
  <property name="permission">Add portal content</property>
  <property name="constructor_path">make_bar</property>
- <property name="add_view_expr">string:${folder_url}/bar_add_view</property>
+ <property name="add_view_expr">string:${folder_url}/baz_add_view</property>
  <property name="link_target"/>
- <property name="immediate_view">bar_view</property>
+ <property name="immediate_view">baz_view</property>
  <property name="global_allow">True</property>
  <property name="filter_content_types">True</property>
  <property name="allowed_content_types">
   <element value="foo"/>
  </property>
  <property name="allow_discussion">True</property>
- <alias from="(Default)" to="bar_view"/>
- <alias from="view" to="bar_view"/>
+ <alias from="(Default)" to="baz_view"/>
+ <alias from="view" to="baz_view"/>
  <action title="View" action_id="view" category="object" condition_expr=""
-    url_expr="string:${object_url}/bar_view"
+    url_expr="string:${object_url}/baz_view"
     icon_expr="" link_target="" visible="True">
   <permission value="View"/>
  </action>
  <action title="Edit" action_id="edit" category="object" condition_expr=""
-    url_expr="string:${object_url}/bar_edit_form"
+    url_expr="string:${object_url}/baz_edit_form"
     icon_expr="" link_target="" visible="True">
   <permission value="Modify portal content"/>
  </action>
@@ -512,6 +522,7 @@ class importTypesToolTests(_TypeInfoSetup):
     _EMPTY_TOOL_EXPORT = _EMPTY_TOOL_EXPORT
     _FILENAME_EXPORT = _FILENAME_EXPORT
     _NORMAL_TOOL_EXPORT = _NORMAL_TOOL_EXPORT
+    _EXTENDED_TOOL_EXPORT = _EXTENDED_TOOL_EXPORT
 
     def test_empty_default_purge(self):
         from Products.CMFCore.exportimport.typeinfo import importTypesTool
@@ -594,7 +605,7 @@ class importTypesToolTests(_TypeInfoSetup):
         self.assertEqual(len(tool.objectIds()), 0)
 
         context = DummyImportContext(site)
-        context._files['types.xml'] = self._NORMAL_TOOL_EXPORT
+        context._files['types.xml'] = self._EXTENDED_TOOL_EXPORT
         context._files['types/foo.xml'] = _FOO_EXPORT % 'foo'
         context._files['types/bar.xml'] = _BAR_CMF21_IMPORT % 'bar'
         context._files['types/baz.xml'] = _BAZ_CMF21_IMPORT % 'baz'

--- a/Products/CMFCore/exportimport/tests/test_typeinfo.py
+++ b/Products/CMFCore/exportimport/tests/test_typeinfo.py
@@ -312,6 +312,50 @@ _BAR_CMF21_IMPORT = """\
 </object>
 """
 
+_BAZ_CMF21_IMPORT = """\
+<?xml version="1.0"?>
+<object name="%s" meta_type="Scriptable Type Information"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <property name="title">Baz</property>
+ <property name="description">Baz things</property>
+ <property name="content_icon"></property>
+ <property name="content_meta_type">Baz Thing</property>
+ <property name="permission">Add portal content</property>
+ <property name="constructor_path">make_bar</property>
+ <property name="add_view_expr">string:${folder_url}/bar_add_view</property>
+ <property name="link_target"/>
+ <property name="immediate_view">bar_view</property>
+ <property name="global_allow">True</property>
+ <property name="filter_content_types">True</property>
+ <property name="allowed_content_types">
+  <element value="foo"/>
+ </property>
+ <property name="allow_discussion">True</property>
+ <alias from="(Default)" to="bar_view"/>
+ <alias from="view" to="bar_view"/>
+ <action title="View" action_id="view" category="object" condition_expr=""
+    url_expr="string:${object_url}/bar_view"
+    icon_expr="" link_target="" visible="True">
+  <permission value="View"/>
+ </action>
+ <action title="Edit" action_id="edit" category="object" condition_expr=""
+    url_expr="string:${object_url}/bar_edit_form"
+    icon_expr="" link_target="" visible="True">
+  <permission value="Modify portal content"/>
+ </action>
+ <action title="Contents" action_id="contents" category="object"
+    condition_expr="" url_expr="string:${object_url}/folder_contents"
+    icon_expr="" link_target="" visible="True">
+  <permission value="Access contents information"/>
+ </action>
+ <action title="Metadata" action_id="metadata" category="object"
+    condition_expr="" url_expr="string:${object_url}/metadata_edit_form"
+    icon_expr="" link_target="" visible="True">
+  <permission value="Modify portal content"/>
+ </action>
+</object>
+"""
+
 _UPDATE_FOO_IMPORT = """\
 <object name="foo">
  <alias from="spam" to="eggs"/>
@@ -553,12 +597,15 @@ class importTypesToolTests(_TypeInfoSetup):
         context._files['types.xml'] = self._NORMAL_TOOL_EXPORT
         context._files['types/foo.xml'] = _FOO_EXPORT % 'foo'
         context._files['types/bar.xml'] = _BAR_CMF21_IMPORT % 'bar'
+        context._files['types/baz.xml'] = _BAZ_CMF21_IMPORT % 'baz'
         importTypesTool(context)
 
-        self.assertEqual(len(tool.objectIds()), 2)
+        self.assertEqual(len(tool.objectIds()), 3)
         self.assertTrue('foo' in tool.objectIds())
         self.assertTrue('bar' in tool.objectIds())
+        self.assertTrue('baz' in tool.objectIds())
         self.assertEqual(tool.bar.icon_expr, 'string:${portal_url}/bar.png')
+        self.assertEqual(tool.baz.icon_expr, '')
 
     def test_normal_update(self):
         from Products.CMFCore.exportimport.typeinfo import importTypesTool

--- a/Products/CMFCore/exportimport/typeinfo.py
+++ b/Products/CMFCore/exportimport/typeinfo.py
@@ -77,7 +77,8 @@ class TypeInformationXMLAdapter(XMLAdapterBase, PropertyManagerHelpers):
                 continue
             if child.getAttribute('name') != 'content_icon':
                 continue
-            icon = 'string:${portal_url}/%s' % self._getNodeText(child)
+            text = self._getNodeText(child)
+            icon = 'string:${portal_url}/%s' % text if text else ''
             new_child = self._doc.createElement('property')
             new_child.setAttribute('name', 'icon_expr')
             new_child.appendChild(self._doc.createTextNode(icon))


### PR DESCRIPTION
I noticed, that when one declares a new portal type and provides no input for `content_icon`, the resulting `icon_expr` autogenerates to `string:${portal_url}/`. The consequence of this is, that whenever the `<img/>` tag for the portal type's icon is going to be shown, the portal site is rendered in an attempt to get the image. This of course massively degrades the site's performance.

My suggestion is to clear this field, if it's missing/empty. My pull request is accompanied with a test checking for that.
