### PR TITLE
Avoid write-on-read when initializing MemberAdapter

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,10 @@ Products.CMFCore Changelog
   `content_icon` was provided.
   [pgrunewald]
 
+- Avoid writing MemberData to the member data tool until
+  properties are actually set.
+  [davisagli]
+
 2.4.0b2 (2017-05-05)
 --------------------
 

--- a/Products/CMFCore/MemberDataTool.py
+++ b/Products/CMFCore/MemberDataTool.py
@@ -235,11 +235,12 @@ class MemberAdapter(object):
         self._tool = tool
         self.__parent__ = aq_parent(aq_inner(user))
         id = user.getId()
-        self._md = tool._members.setdefault(id, MemberData(id))
+        self._md = tool._members.get(id, MemberData(id))
 
     @security.private
     def notifyModified(self):
         # Links self to parent for full persistence.
+        self._tool._members[id] = self._md
         self._tool.registerMemberData(self._md, self.getId())
 
     @security.public

--- a/Products/CMFCore/MemberDataTool.py
+++ b/Products/CMFCore/MemberDataTool.py
@@ -240,7 +240,6 @@ class MemberAdapter(object):
     @security.private
     def notifyModified(self):
         # Links self to parent for full persistence.
-        self._tool._members[id] = self._md
         self._tool.registerMemberData(self._md, self.getId())
 
     @security.public

--- a/Products/CMFCore/tests/test_MemberDataTool.py
+++ b/Products/CMFCore/tests/test_MemberDataTool.py
@@ -157,6 +157,17 @@ class MemberAdapterTests(unittest.TestCase):
         verifyClass(IMemberData, self._getTargetClass())
         verifyClass(IUser, self._getTargetClass())
 
+    def test_init_does_not_persist_change(self):
+        user = DummyUser('bob', 'pw', ['Role'], [])
+        self._makeOne(user, self.site.portal_memberdata)
+        self.assertNotIn(user.getId(), self.site.portal_memberdata._members)
+
+    def test_notifyModified_persists_change(self):
+        user = DummyUser('bob', 'pw', ['Role'], [])
+        member = self._makeOne(user, self.site.portal_memberdata)
+        member.notifyModified()
+        self.assertIn(user.getId(), self.site.portal_memberdata._members)
+
     def test_setProperties(self):
         user = DummyUser('bob', 'pw', ['Role'], [])
         user = user.__of__(self.site.acl_users)


### PR DESCRIPTION
This avoids writing a MemberData object to the database when MemberAdapter is being looked up for reads only. (The change is needed to avoid triggering CSRF protection errors in Plone tests.)