### PR TITLE
Be more consistent across different set implementation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Products.CMFCore Changelog
 2.4.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix Python 3 compatibility.
+  [ale-rt]
 
 
 2.4.0b3 (2018-03-16)

--- a/Products/CMFCore/indexing.py
+++ b/Products/CMFCore/indexing.py
@@ -95,7 +95,7 @@ def processQueue():
 
 
 class PathProxy(ProxyBase):
-    
+
     def __init__(self, obj):
         super(PathProxy, self).__init__(obj)
         self._old_path = obj.getPhysicalPath()
@@ -189,7 +189,7 @@ class IndexQueue(local):
                 # and takes precedence
                 if attr and iattr and isinstance(attr, (tuple, list)) and \
                         isinstance(iattr, (tuple, list)):
-                    attr = list(set(attr).union(iattr))
+                    attr = sorted(set(attr).union(iattr))
                 else:
                     attr = []
 

--- a/Products/CMFCore/tests/test_CatalogIndexing.py
+++ b/Products/CMFCore/tests/test_CatalogIndexing.py
@@ -271,7 +271,7 @@ class QueueTests(CleanUp, TestCase):
 
         queue.setState([(REINDEX, 'A', ('a', 'b'), 1), (REINDEX, 'A', ('b', 'c'), 1)])
         queue.optimize()
-        self.failUnlessEqual(queue.getState(), [(REINDEX, 'A', ['a', 'c', 'b'], 1)])
+        self.failUnlessEqual(queue.getState(), [(REINDEX, 'A', ['a', 'b', 'c'], 1)])
 
         queue.setState([(INDEX, 'A', None, None), (REINDEX, 'A', None, 1)])
         queue.optimize()
@@ -455,7 +455,7 @@ class UnindexWrapperTests(TestCase):
         wrapped = wrap(unwrapped)
 
         self.failUnless(unwrapped.getPhysicalPath()[-1], 'testcontent')
-        self.assertEquals(unwrapped.getPhysicalPath(), 
+        self.assertEquals(unwrapped.getPhysicalPath(),
                           wrapped.getPhysicalPath())
         self.assertEquals(hash(unwrapped), hash(wrapped))
         self.assertEquals(unwrapped.Title(), wrapped.Title())


### PR DESCRIPTION
Not sorting the set converted to list results in different order on Python 2.7 and Python 3. 

Compare:
```
Python 2.7.14 (default, Sep 23 2017, 22:06:14) 
[GCC 7.2.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> list(set(['a', 'b']).union(['b', 'c']))
['a', 'c', 'b']
```
vs:
```
Python 3.6.3 (default, Oct  3 2017, 21:45:48) 
[GCC 7.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> list(set(['a', 'b']).union(['b', 'c']))
['b', 'a', 'c']
```

This PR make the optimize method consistent.

