### PR TITLE
 Be sure we are comparing the same type

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Products.CMFCore Changelog
 2.4.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix Python 3 compatibility.
+  [ale-rt]
 
 
 2.4.0b3 (2018-03-16)

--- a/Products/CMFCore/tests/test_FSFile.py
+++ b/Products/CMFCore/tests/test_FSFile.py
@@ -14,7 +14,6 @@
 """
 
 import unittest
-import Testing
 
 import os
 
@@ -73,7 +72,7 @@ class FSFileTests(TransactionalTest, FSDVTest):
         _path, ref = self._extractFile('test_file.swf')
         file = self._makeOne('test_file', 'test_file.swf')
         file = file.__of__(self.app)
-        self.assertEqual(len(str(file)), len(ref))
+        self.assertEqual(len(str(file)), len(str(ref)))
 
     def test_index_html(self):
         path, ref = self._extractFile('test_file.swf')


### PR DESCRIPTION
This makes the test `test_str` pass on Python3, where ref is bytes