### PR TITLE
Test on Python 3.6 using TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ sudo: false
 dist: trusty
 python:
     - "2.7"
+    - "3.6"
+env:
+matrix:
+    allow_failures:
+    - python: "3.6"
 install:
     - python bootstrap.py
     - bin/buildout


### PR DESCRIPTION
The Python 3 failures should only be allowed temporarily to see the progress of the Python 3 fixes.