### PR TITLE
Fix notifyModified called on a wrong object.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,8 @@ Products.CMFCore Changelog
 
 - Fix Python 3 compatibility.
   [ale-rt]
+- Fix notifyModified called on a wrong object.
+  [mamico]
 
 
 2.4.0b3 (2018-03-16)

--- a/Products/CMFCore/CatalogTool.py
+++ b/Products/CMFCore/CatalogTool.py
@@ -317,7 +317,7 @@ class CatalogTool(UniqueObject, ZCatalog, ActionProviderBase):
         if not CATALOG_OPTIMIZATION_DISABLED:
             if idxs in (None, []) and \
                     hasattr(aq_base(object), 'notifyModified'):
-                self.notifyModified()
+                object.notifyModified()
             obj = filterTemporaryItems(object)
             if obj is not None:
                 indexer = getQueue()


### PR DESCRIPTION
In a Plone 5.1 installation with many concurrent changes we have found a lot of ConflictError in PloneSite object. After a deeply investigation I saw that the problem could be on CatalogTool.reindexObject where notifyModified is called on self (and then on PloneSite acquisition) instead of the object involved.

If my guess is correct and the fix valid, I would ask to do backport also in the 2.2 branch (used in Plone 5.1).  If it can be useful I can do another PR for that.