### PR TITLE
Declare the proper dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(name='Products.%s' % NAME,
           'Products.MailHost >= 4.0',
           'Products.PythonScripts',
           'Products.StandardCacheManagers',
-          'Products.ZCTextIndex',
+          'Products.ZCatalog',  # Products.ZCTextIndex lives there now
           'six',
           'zope.interface >= 3.8',
           ],


### PR DESCRIPTION
The content of `Products.ZCTextIndex` moved to `Products.ZCatalog` which was a non-declared dependency any way.