### PR TITLE
Drop support for running tests with ``python setup.py test``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Products.CMFCore Changelog
 2.4.0b6 (unreleased)
 --------------------
 
+- removed support for testing using ``'python setup.py test``
+  (`#51 <https://github.com/zopefoundation/Products.CMFCore/issues/51>_`)
+
 - Add more ZMI icons for the Zope 4 ZMI
   (`#47 <https://github.com/zopefoundation/Products.CMFCore/issues/47>`_)
 

--- a/Products/CMFCore/utils.py
+++ b/Products/CMFCore/utils.py
@@ -534,6 +534,7 @@ class UniqueObject(ImmutableId):
     """ Base class for objects which cannot be "overridden" / shadowed.
     """
     zmi_icon = 'fas fa-wrench'
+
     def _getUNIQUE(self):
         return UNIQUE
 

--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,6 @@ setup(name='Products.%s' % NAME,
       include_package_data=True,
       namespace_packages=['Products'],
       zip_safe=False,
-      setup_requires=[
-          'eggtestinfo',
-      ],
       install_requires=[
           'setuptools',
           'Zope >= 4.0b8.dev0',
@@ -64,20 +61,12 @@ setup(name='Products.%s' % NAME,
           'six',
           'zope.interface >= 3.8',
           ],
-      tests_require=[
-          'zope.testing >= 3.7.0',
-          'Products.StandardCacheManagers',
-          ],
       extras_require={
           'test': ['Products.StandardCacheManagers'],
           'zsql': ['Products.ZSQLMethods >= 3.0.0b1'],
           },
-      test_loader='zope.testing.testrunner.eggsupport:SkipLayers',
-      test_suite='Products.%s' % NAME,
       entry_points="""
       [zope2.initialize]
       Products.%s = Products.%s:initialize
-      [distutils.commands]
-      ftest = zope.testing.testrunner.eggsupport:ftest
       """ % (NAME, NAME),
       )


### PR DESCRIPTION
There is no need to drag along another way of running tests, which (AFAIK) no one is using at this point. This allows us to drop the dependency on ``eggtestinfo`` as well.