### PR TITLE
Fix notifyModified called on a wrong object. (backport #44 to 2.2)

### DIFF
--- a/Products/CMFCore/CHANGES.txt
+++ b/Products/CMFCore/CHANGES.txt
@@ -4,6 +4,10 @@ Products.CMFCore Changelog
 2.2.13 (unreleased)
 -------------------
 
+Bug fixes:
+
+- Fix notifyModified called on a wrong object. PR #44
+  [mamico]
 
 2.2.12 (2017-05-05)
 -------------------

--- a/Products/CMFCore/CatalogTool.py
+++ b/Products/CMFCore/CatalogTool.py
@@ -310,7 +310,7 @@ class CatalogTool(UniqueObject, ZCatalog, ActionProviderBase):
         if not CATALOG_OPTIMIZATION_DISABLED:
             if idxs in (None, []) and \
                     hasattr(aq_base(object), 'notifyModified'):
-                self.notifyModified()
+                object.notifyModified()
             obj = filterTemporaryItems(object)
             if obj is not None:
                 indexer = getQueue()


### PR DESCRIPTION
backport #44 Products.CMFCore 2.2.x still used for stable Plone 5.1