### PR TITLE
Backport plone/collective.indexing#16

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Products.CMFCore Changelog
 2.4.0b7 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Backport plone/collective.indexing#16 to use the catalog queue
+  also when reindexing the object security
+  (`#58 <https://github.com/zopefoundation/Products.CMFCore/issues/58>_`)
 
 
 2.4.0b6 (2018-12-14)

--- a/Products/CMFCore/CMFCatalogAware.py
+++ b/Products/CMFCore/CMFCatalogAware.py
@@ -119,10 +119,8 @@ class CatalogAware(Base):
                 logger.warning("reindexObjectSecurity: Cannot get %s from "
                                "catalog", brain_path)
                 continue
-            # Recatalog with the same catalog uid.
             s = getattr(ob, '_p_changed', 0)
-            catalog.reindexObject(ob, idxs=self._cmf_security_indexes,
-                                  update_metadata=0, uid=brain_path)
+            ob.reindexObject(idxs=self._cmf_security_indexes)
             if s is None:
                 ob._p_deactivate()
 


### PR DESCRIPTION
This PR is an alternative for #59 that should have the advantage of using the queue when reindexing the security attributes of an object (and for this reason it will trigger make all the registered `IIndexQueueProcessor` aware about possible security changes).

This is a backport of plone/collective.indexing#16.