### PR TITLE
Added fallback for missing zope.OFS.bbb

### DIFF
--- a/Products/CMFCore/FSDTMLMethod.py
+++ b/Products/CMFCore/FSDTMLMethod.py
@@ -22,10 +22,6 @@ from AccessControl.SecurityManagement import getSecurityManager
 from App.special_dtml import HTML
 from App.special_dtml import DTMLFile
 from DocumentTemplate.security import RestrictedDTML
-try:
-    from OFS.bbb import HAS_ZSERVER
-except:
-    HAS_ZSERVER = False
 from OFS.DTMLMethod import DTMLMethod
 from OFS.DTMLMethod import decapitate
 from OFS.DTMLMethod import guess_content_type
@@ -38,6 +34,7 @@ from .FSObject import FSObject
 from .permissions import FTPAccess
 from .permissions import View
 from .permissions import ViewManagementScreens
+from .utils import HAS_ZSERVER
 from .utils import _checkConditionalGET
 from .utils import _dtmldir
 from .utils import _setCacheHeaders

--- a/Products/CMFCore/FSPageTemplate.py
+++ b/Products/CMFCore/FSPageTemplate.py
@@ -22,10 +22,6 @@ from AccessControl.class_init import InitializeClass
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from AccessControl.SecurityManagement import getSecurityManager
 from App.special_dtml import DTMLFile
-try:
-    from OFS.bbb import HAS_ZSERVER
-except:
-    HAS_ZSERVER = False
 from Products.PageTemplates.PageTemplate import PageTemplate
 from Products.PageTemplates.utils import charsetFromMetaEquiv
 from Products.PageTemplates.utils import encodingFromXMLPreamble
@@ -40,6 +36,7 @@ from .FSObject import FSObject
 from .permissions import FTPAccess
 from .permissions import View
 from .permissions import ViewManagementScreens
+from .utils import HAS_ZSERVER
 from .utils import _checkConditionalGET
 from .utils import _dtmldir
 from .utils import _setCacheHeaders

--- a/Products/CMFCore/testing.py
+++ b/Products/CMFCore/testing.py
@@ -13,10 +13,6 @@
 """ Unit test mixin classes and layers.
 """
 
-try:
-    from OFS.bbb import HAS_ZSERVER
-except:
-    HAS_ZSERVER = False
 from OFS.SimpleItem import SimpleItem
 from Products.GenericSetup.utils import BodyAdapterBase
 from Testing.ZopeTestCase.layer import ZopeLite
@@ -30,6 +26,7 @@ from zope.publisher.interfaces.http import IHTTPRequest
 from zope.testing.cleanup import cleanUp
 
 from .interfaces import IWorkflowDefinition
+from .utils import HAS_ZSERVER
 
 
 class ConformsToFolder:

--- a/Products/CMFCore/tests/test_TypesTool.py
+++ b/Products/CMFCore/tests/test_TypesTool.py
@@ -17,14 +17,11 @@ import unittest
 import warnings
 
 from AccessControl.Permission import Permission
-try:
-    from OFS.bbb import HAS_ZSERVER
-except:
-    HAS_ZSERVER = False
 from zope.component import getSiteManager
 
 from ..interfaces import IWorkflowTool
 from ..testing import FunctionalZCMLLayer
+from ..utils import HAS_ZSERVER
 from .base.testcase import SecurityTest
 
 

--- a/Products/CMFCore/utils.py
+++ b/Products/CMFCore/utils.py
@@ -21,6 +21,7 @@ from os import path as os_path
 from os.path import abspath
 from warnings import warn
 
+import pkg_resources
 import six
 from six.moves._thread import allocate_lock
 
@@ -58,6 +59,12 @@ from .exceptions import AccessControl_Unauthorized
 from .exceptions import NotFound
 from .interfaces import ICachingPolicyManager
 
+
+HAS_ZSERVER = True
+try:
+    dist = pkg_resources.get_distribution('ZServer')
+except pkg_resources.DistributionNotFound:
+    HAS_ZSERVER = False
 
 SUBTEMPLATE = '__SUBTEMPLATE__'
 ProductsPath = [abspath(ppath) for ppath in Products.__path__]


### PR DESCRIPTION
hi @dataflake,
in respect to your comment https://github.com/zopefoundation/Zope/pull/696#issuecomment-530328174 I provide a quickfix working as fallback for the upward compatibility (missing Zope.ZServer / bbb.HAS_ZSERVER).
Best regards
fh
