### PR TITLE
Add missing arguments to reindexObject

### DIFF
--- a/Products/CMFCore/CMFCatalogAware.py
+++ b/Products/CMFCore/CMFCatalogAware.py
@@ -79,7 +79,7 @@ class CatalogAware(Base):
             catalog.unindexObject(self)
 
     @security.protected(ModifyPortalContent)
-    def reindexObject(self, idxs=[]):
+    def reindexObject(self, idxs=[], update_metadata=1, uid=False):
         """ Reindex the object in the portal catalog.
         """
         if idxs == []:
@@ -88,7 +88,11 @@ class CatalogAware(Base):
                 self.notifyModified()
         catalog = self._getCatalogTool()
         if catalog is not None:
-            catalog.reindexObject(self, idxs=idxs)
+            catalog.reindexObject(
+                self,
+                idxs=idxs,
+                update_metadata=update_metadata,
+                uid=uid)
 
     _cmf_security_indexes = ('allowedRolesAndUsers',)
 

--- a/Products/CMFCore/tests/test_CMFCatalogAware.py
+++ b/Products/CMFCore/tests/test_CMFCatalogAware.py
@@ -93,7 +93,8 @@ class DummyCatalog(SimpleItem):
         self.log.append('index %s' % physicalpath(ob))
 
     def reindexObject(self, ob, idxs=[], update_metadata=0, uid=None):
-        self.log.append('reindex %s %s' % (physicalpath(ob), idxs))
+        self.log.append(
+            'reindex %s %s %i' % (physicalpath(ob), idxs, update_metadata))
 
     def unindexObject(self, ob):
         self.log.append('unindex %s' % physicalpath(ob))
@@ -174,6 +175,13 @@ class CMFCatalogAwareTests(unittest.TestCase, LogInterceptor):
         foo.reindexObject(idxs=['bar'])
         self.assertEqual(cat.log, ["reindex /site/foo ['bar']"])
         self.assertFalse(foo.notified)
+
+    def test_reindexObject_metadata(self):
+        foo = self.site.foo
+        cat = self.ctool
+        foo.reindexObject(update_metadata=0)
+        self.assertEqual(cat.log, ['reindex /site/foo [] 0'])
+        self.assertTrue(foo.notified)
 
     def test_reindexObjectSecurity(self):
         foo = self.site.foo

--- a/Products/CMFCore/tests/test_CMFCatalogAware.py
+++ b/Products/CMFCore/tests/test_CMFCatalogAware.py
@@ -166,14 +166,14 @@ class CMFCatalogAwareTests(unittest.TestCase, LogInterceptor):
         foo = self.site.foo
         cat = self.ctool
         foo.reindexObject()
-        self.assertEqual(cat.log, ['reindex /site/foo []'])
+        self.assertEqual(cat.log, ['reindex /site/foo [] 1'])
         self.assertTrue(foo.notified)
 
     def test_reindexObject_idxs(self):
         foo = self.site.foo
         cat = self.ctool
         foo.reindexObject(idxs=['bar'])
-        self.assertEqual(cat.log, ["reindex /site/foo ['bar']"])
+        self.assertEqual(cat.log, ["reindex /site/foo ['bar'] 1"])
         self.assertFalse(foo.notified)
 
     def test_reindexObject_metadata(self):
@@ -194,9 +194,9 @@ class CMFCatalogAwareTests(unittest.TestCase, LogInterceptor):
         foo.reindexObjectSecurity()
         log = sorted(cat.log)
         self.assertEqual(log, [
-            'reindex /site/foo %s' % str(CMF_SECURITY_INDEXES),
-            'reindex /site/foo/bar %s' % str(CMF_SECURITY_INDEXES),
-            'reindex /site/foo/hop %s' % str(CMF_SECURITY_INDEXES),
+            'reindex /site/foo %s 1' % str(CMF_SECURITY_INDEXES),
+            'reindex /site/foo/bar %s 1' % str(CMF_SECURITY_INDEXES),
+            'reindex /site/foo/hop %s 1' % str(CMF_SECURITY_INDEXES),
             ])
         self.assertFalse(foo.notified)
         self.assertFalse(bar.notified)
@@ -225,8 +225,9 @@ class CMFCatalogAwareTests(unittest.TestCase, LogInterceptor):
         cat = self.ctool
         cat.setObs([foo, missing])
         foo.reindexObjectSecurity()
-        self.assertEqual(cat.log,
-                         ['reindex /site/foo %s' % str(CMF_SECURITY_INDEXES)])
+        self.assertEqual(
+            cat.log,
+            ['reindex /site/foo %s 1' % str(CMF_SECURITY_INDEXES)])
         self.assertFalse(foo.notified)
         self.assertFalse(missing.notified)
         self.assertEqual(len(self.logged), 1)  # logging because no raise


### PR DESCRIPTION
[CatalogAware.reindexObject](https://github.com/zopefoundation/Products.CMFCore/blob/master/Products/CMFCore/CMFCatalogAware.py#L91) calls [CatalogTool.reindexObject](https://github.com/zopefoundation/Products.CMFCore/blob/master/Products/CMFCore/CatalogTool.py#L314) which expects two extra arguments: `update_metadata` and `uid`.

This way, regular `CMFAware` objects can be reindexed without updating the metadata, if they wish so.