### PR TITLE
Fix encoding detection for XML files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Products.CMFCore Changelog
 2.4.3 (unreleased)
 ------------------
 
+- fix encoding detection for XML files
+  (`#85 <https://github.com/zopefoundation/Products.CMFCore/issues/85>`_)
+
 
 2.4.2 (2019-11-28)
 ------------------

--- a/Products/CMFCore/FSPageTemplate.py
+++ b/Products/CMFCore/FSPageTemplate.py
@@ -115,7 +115,10 @@ class FSPageTemplate(FSObject, Script, PageTemplate):
                     # Smells like xml
                     # set "content_type" from the XML declaration
                     if xml_info.group(1):
-                        encoding = xml_info.group(1).decode('ascii')
+                        if six.PY3:
+                            encoding = xml_info.group(1).decode('ascii')
+                        else:
+                            encoding = xml_info.group(1)
                     else:
                         encoding = 'utf-8'
                     self.content_type = 'text/xml; charset=%s' % encoding

--- a/Products/CMFCore/FSPageTemplate.py
+++ b/Products/CMFCore/FSPageTemplate.py
@@ -114,7 +114,10 @@ class FSPageTemplate(FSObject, Script, PageTemplate):
                 if xml_info:
                     # Smells like xml
                     # set "content_type" from the XML declaration
-                    encoding = xml_info.group(1) or 'utf-8'
+                    if xml_info.group(1):
+                        encoding = xml_info.group(1).decode('ascii')
+                    else:
+                        encoding = 'utf-8'
                     self.content_type = 'text/xml; charset=%s' % encoding
 
             if not isinstance(data, six.text_type):

--- a/Products/CMFCore/tests/fake_skins/fake_skin/testXMLPT_with_encoding.pt
+++ b/Products/CMFCore/tests/fake_skins/fake_skin/testXMLPT_with_encoding.pt
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<test xmlns:tal="http://xml.zope.org/namespaces/tal"
+   tal:content="context/getId">This is only a test</test>

--- a/Products/CMFCore/tests/test_FSPageTemplate.py
+++ b/Products/CMFCore/tests/test_FSPageTemplate.py
@@ -80,6 +80,15 @@ class FSPageTemplateTests(TransactionalTest, FSPTMaker):
         self.assertEqual(self.RESPONSE.getHeader('content-type'),
                          'text/html; charset=utf-8')
 
+    def test_ContentTypeDetection(self):
+        script = self._makeOne(
+            'testXMLPT_with_encoding', 'testXMLPT_with_encoding.pt')
+        script = script.__of__(self.app)
+        script()
+        self.assertEqual(script.content_type, 'text/xml; charset=utf-8')
+        self.assertEqual(self.RESPONSE.getHeader('content-type'),
+                         'text/xml; charset=utf-8')
+
     def test_ContentTypeOverride(self):
         script = self._makeOne('testPT_utf8', 'testPT_utf8.pt')
         script = script.__of__(self.app)


### PR DESCRIPTION
In order to detect the correct encoding, XML files are read in binary
format and then the encoding information is extracted by using a
regular expression.

The result could not be used until decoded into a string. This is done
now.

There were two possible fixes - either decode the found encoding information, or skip the extraction completely. @icemac suggested to go with the decoding step.

modified:   CHANGES.rst
modified:   Products/CMFCore/FSPageTemplate.py
new file:   Products/CMFCore/tests/fake_skins/fake_skin/testXMLPT_with_encoding.pt
modified:   Products/CMFCore/tests/test_FSPageTemplate.py

Fixes #85.