### PR TITLE
Fix tests to be able to run on Zope 4.3.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Products.CMFCore Changelog
 2.4.5 (unreleased)
 ------------------
 
+- Fix tests to be able to run on Zope 4.3.
+
 
 2.4.4 (2020-01-29)
 ------------------

--- a/Products/CMFCore/tests/test_ActionInformation.py
+++ b/Products/CMFCore/tests/test_ActionInformation.py
@@ -175,6 +175,9 @@ class DummyRequest:
     def __len__(self):
         return len(self._data)
 
+    def getVirtualRoot(self):
+        return '/'
+
 
 class ActionInfoTests(unittest.TestCase):
 


### PR DESCRIPTION
Zope 4.3 calls `REQUEST.getVirtualRoot()` in `manage_tabnav`
since https://github.com/zopefoundation/Zope/commit/3a0a423e271113e3ac3e78c8a7076e22c21a050d