### PR TITLE
Fix not declared dependency on `Products.DCWorkflow`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Products.CMFCore Changelog
 
 - Fix tests to be able to run on Zope 4.3.
 
+- Fix not declared dependency on ``Products.DCWorkflow`` in `subscribers.zcml`.
+
 
 2.4.4 (2020-01-29)
 ------------------

--- a/Products/CMFCore/subscribers.zcml
+++ b/Products/CMFCore/subscribers.zcml
@@ -1,5 +1,6 @@
 <configure
-    xmlns="http://namespaces.zope.org/zope">
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:zcml="http://namespaces.zope.org/zcml">
 
   <!-- See docstring on subscribers.py -->
 
@@ -39,7 +40,7 @@
            zope.lifecycleevent.interfaces.IObjectMovedEvent"
       trusted="y" />
 
-  <subscriber
+  <subscriber zcml:condition="installed Products.DCWorkflow"
       handler="Products.CMFCore.subscribers.objectTransitioned"
       for="Products.DCWorkflow.interfaces.IAfterTransitionEvent"
       trusted="y" />


### PR DESCRIPTION
`subscribers.zcml` is not loaded in any test, so this bug could hide until today.
Maybe it could be an idea for a future PR to write such a test as `subscribers.py` is also completely untested.