### PR TITLE
fix 87

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Products.CMFCore Changelog
 2.4.7 (unreleased)
 ------------------
 
-- Change the default value of uid to None on CMFCatalogAware's reindexObject method (`#80 <https://github.com/zopefoundation/Products.CMFCore/issue`_)
+- Change the default value of uid to None on CMFCatalogAware's reindexObject method (`#87 <https://github.com/zopefoundation/Products.CMFCore/issues/87>`_)
 
 
 2.4.6 (2020-04-14)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Products.CMFCore Changelog
 2.4.7 (unreleased)
 ------------------
 
+- Change the default value of uid to None on CMFCatalogAware's reindexObject method (`#80 <https://github.com/zopefoundation/Products.CMFCore/issue`_)
+
 
 2.4.6 (2020-04-14)
 ------------------

--- a/Products/CMFCore/CMFCatalogAware.py
+++ b/Products/CMFCore/CMFCatalogAware.py
@@ -79,7 +79,7 @@ class CatalogAware(Base):
             catalog.unindexObject(self)
 
     @security.protected(ModifyPortalContent)
-    def reindexObject(self, idxs=[], update_metadata=1, uid=False):
+    def reindexObject(self, idxs=[], update_metadata=1, uid=None):
         """ Reindex the object in the portal catalog.
         """
         if idxs == []:


### PR DESCRIPTION
Sorry this is so far behind the initial issue submission given how tiny the change is. Covid pushed it back because without a work printer it was harder to print and sign the contributor agreement!

There is no test accompanying this fix at the moment. Given the nature of it, I am not sure what such a test should look like. Advice?