### PR TITLE
Fix indexing queue issue with UNINDEX followed by REINDEX

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Products.CMFCore Changelog
 2.4.8 (unreleased)
 ------------------
 
+- Fix an issue with the indexing queue where an UNINDEX followed by REINDEX was
+  wrongly optimized to UNINDEX instead of REINDEX.
+  (`#96 <https://github.com/zopefoundation/Products.CMFCore/pull/96>`_)
+
 
 2.4.7 (2020-06-24)
 ------------------

--- a/Products/CMFCore/indexing.py
+++ b/Products/CMFCore/indexing.py
@@ -183,10 +183,13 @@ class IndexQueue(local):
             if op == INDEX and iop == UNINDEX:
                 del res[hash_id]
             else:
-                # Operators are -1, 0 or 1 which makes it safe to add them
-                op += iop
-                # operator always within -1 and 1
-                op = min(max(op, UNINDEX), INDEX)
+                if op == UNINDEX and iop == REINDEX:
+                    op = REINDEX
+                else:
+                    # Operators are -1, 0 or 1 which makes it safe to add them
+                    op += iop
+                    # operator always within -1 and 1
+                    op = min(max(op, UNINDEX), INDEX)
 
                 # Handle attributes, None means all fields,
                 # and takes precedence

--- a/Products/CMFCore/tests/test_CatalogIndexing.py
+++ b/Products/CMFCore/tests/test_CatalogIndexing.py
@@ -264,6 +264,10 @@ class QueueTests(CleanUp, TestCase):
         queue.optimize()
         self.assertEqual(queue.getState(), [(REINDEX, 'A', [], None)])
 
+        queue.setState([(UNINDEX, 'A', None, None), (REINDEX, 'A', [], 1)])
+        queue.optimize()
+        self.assertEqual(queue.getState(), [(REINDEX, 'A', [], 1)])
+
     def testOptimizeQueueWithAttributes(self):
         queue = self.queue
 


### PR DESCRIPTION
See https://github.com/plone/Products.CMFPlone/issues/2585#issuecomment-653548738 for details.
An unindex followed by reindex gives only a unindex. It should really be doing a reindex.

The issue is that
```
[(UNINDEX, <Image at /Plone/folder/myimage.jpg>, None, None), (REINDEX, <Image at /Plone/folder/myimage.jpg>, [], 1)]
```

optimize to:

```
[(UNINDEX, <Image at /Plone/folder/myimage.jpg>, [], 1)]
```

instead of:

```
[(REINDEX, <Image at /Plone/folder/myimage.jpg>, [], 1)]
```

In the indexing.py file the line that is wrong is
https://github.com/zopefoundation/Products.CMFCore/blob/55fe79456990b530a00ec3a41005660403421087/Products/CMFCore/indexing.py#L187

in the case of `op = UNINDEX (-1)` and `iop = REINDEX (0)`, op stays at `-1`, but it should be at `0`.
The `op += iop` works well when you have a symmetry `UNINDEX (-1)` followed by `INDEX (1)`, it gives `REINDEX (0)`.
But here in reality, we may get `op = UNINDEX (-1)` followed by `iop = REINDEX (0)`
