### PR TITLE
Update isort to version 5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Products.CMFCore Changelog
 2.4.9 (unreleased)
 ------------------
 
+- update configuration for version 5 of ``isort``
+
 
 2.4.8 (2020-07-03)
 ------------------

--- a/Products/CMFCore/CMFBTreeFolder.py
+++ b/Products/CMFCore/CMFBTreeFolder.py
@@ -15,8 +15,9 @@
 
 from AccessControl.class_init import InitializeClass
 from AccessControl.SecurityInfo import ClassSecurityInfo
-from Products.BTreeFolder2.BTreeFolder2 import BTreeFolder2Base
 from zope.component.factory import Factory
+
+from Products.BTreeFolder2.BTreeFolder2 import BTreeFolder2Base
 
 from .permissions import AddPortalFolders
 from .PortalFolder import PortalFolder

--- a/Products/CMFCore/CatalogTool.py
+++ b/Products/CMFCore/CatalogTool.py
@@ -22,8 +22,6 @@ from AccessControl.SecurityManagement import getSecurityManager
 from Acquisition import aq_base
 from App.special_dtml import DTMLFile
 from DateTime.DateTime import DateTime
-from Products.PluginIndexes.util import safe_callable
-from Products.ZCatalog.ZCatalog import ZCatalog
 from zope.component import adapts
 from zope.component import queryMultiAdapter
 from zope.component import queryUtility
@@ -32,6 +30,9 @@ from zope.interface import providedBy
 from zope.interface.declarations import ObjectSpecification
 from zope.interface.declarations import ObjectSpecificationDescriptor
 from zope.interface.declarations import getObjectSpecification
+
+from Products.PluginIndexes.util import safe_callable
+from Products.ZCatalog.ZCatalog import ZCatalog
 
 from .ActionProviderBase import ActionProviderBase
 from .indexing import filterTemporaryItems

--- a/Products/CMFCore/FSObject.py
+++ b/Products/CMFCore/FSObject.py
@@ -28,8 +28,9 @@ from DateTime.DateTime import DateTime
 from OFS.Cache import Cacheable
 from OFS.role import RoleManager
 from OFS.SimpleItem import Item
-from Products.PythonScripts.standard import html_quote
 from zope.component import getUtility
+
+from Products.PythonScripts.standard import html_quote
 
 from .interfaces import ISkinsTool
 from .permissions import ManagePortal

--- a/Products/CMFCore/FSPythonScript.py
+++ b/Products/CMFCore/FSPythonScript.py
@@ -22,8 +22,9 @@ from AccessControl.SecurityInfo import ClassSecurityInfo
 from App.special_dtml import DTMLFile
 from ComputedAttribute import ComputedAttribute
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
-from Products.PythonScripts.PythonScript import PythonScript
 from Shared.DC.Scripts.Script import Script
+
+from Products.PythonScripts.PythonScript import PythonScript
 
 from .DirectoryView import registerFileExtension
 from .DirectoryView import registerMetaType

--- a/Products/CMFCore/FSZSQLMethod.py
+++ b/Products/CMFCore/FSZSQLMethod.py
@@ -20,6 +20,7 @@ from AccessControl.SecurityInfo import ClassSecurityInfo
 from Acquisition import ImplicitAcquisitionWrapper
 from App.config import getConfiguration
 from App.special_dtml import DTMLFile
+
 from Products.ZSQLMethods.SQL import SQL
 
 from .DirectoryView import registerFileExtension

--- a/Products/CMFCore/SkinsTool.py
+++ b/Products/CMFCore/SkinsTool.py
@@ -26,10 +26,11 @@ from OFS.Image import Image
 from OFS.ObjectManager import REPLACEABLE
 from Persistence import PersistentMapping
 from Products.PageTemplates.ZopePageTemplate import ZopePageTemplate
-from Products.PythonScripts.PythonScript import PythonScript
 from zope.component import getUtility
 from zope.globalrequest import getRequest
 from zope.interface import implementer
+
+from Products.PythonScripts.PythonScript import PythonScript
 
 from .ActionProviderBase import ActionProviderBase
 from .DirectoryView import base_ignore

--- a/Products/CMFCore/__init__.py
+++ b/Products/CMFCore/__init__.py
@@ -15,6 +15,7 @@
 
 try:
     import Products.ZSQLMethods  # noqa
+
     from . import FSZSQLMethod
     HAVE_ZSQL = True
 except ImportError:

--- a/Products/CMFCore/browser/actions.py
+++ b/Products/CMFCore/browser/actions.py
@@ -15,11 +15,12 @@
 
 from xml.dom.minidom import parseString
 
+from zope.component import queryMultiAdapter
+from zope.component import queryUtility
+
 from Products.GenericSetup.browser.utils import AddWithPresettingsViewBase
 from Products.GenericSetup.interfaces import INode
 from Products.GenericSetup.interfaces import ISetupTool
-from zope.component import queryMultiAdapter
-from zope.component import queryUtility
 
 from ..ActionInformation import Action
 from ..ActionInformation import ActionCategory

--- a/Products/CMFCore/browser/typeinfo.py
+++ b/Products/CMFCore/browser/typeinfo.py
@@ -15,11 +15,12 @@
 
 from xml.dom.minidom import parseString
 
+from zope.component import queryMultiAdapter
+from zope.component import queryUtility
+
 from Products.GenericSetup.browser.utils import AddWithPresettingsViewBase
 from Products.GenericSetup.interfaces import IBody
 from Products.GenericSetup.interfaces import ISetupTool
-from zope.component import queryMultiAdapter
-from zope.component import queryUtility
 
 from ..TypesTool import FactoryTypeInformation
 from ..TypesTool import ScriptableTypeInformation

--- a/Products/CMFCore/exportimport/actions.py
+++ b/Products/CMFCore/exportimport/actions.py
@@ -13,6 +13,9 @@
 """Actions tool node adapters.
 """
 
+from zope.component import adapts
+from zope.component import getSiteManager
+
 from Products.GenericSetup.interfaces import ISetupEnviron
 from Products.GenericSetup.utils import I18NURI
 from Products.GenericSetup.utils import NodeAdapterBase
@@ -21,8 +24,6 @@ from Products.GenericSetup.utils import PropertyManagerHelpers
 from Products.GenericSetup.utils import XMLAdapterBase
 from Products.GenericSetup.utils import exportObjects
 from Products.GenericSetup.utils import importObjects
-from zope.component import adapts
-from zope.component import getSiteManager
 
 from ..interfaces import IAction
 from ..interfaces import IActionCategory

--- a/Products/CMFCore/exportimport/cachingpolicymgr.py
+++ b/Products/CMFCore/exportimport/cachingpolicymgr.py
@@ -13,15 +13,16 @@
 """Caching policy manager xml adapters and setup handlers.
 """
 
+from zope.component import adapts
+from zope.component import getSiteManager
+from zope.component import queryMultiAdapter
+
 from Products.GenericSetup.interfaces import INode
 from Products.GenericSetup.interfaces import ISetupEnviron
 from Products.GenericSetup.utils import NodeAdapterBase
 from Products.GenericSetup.utils import XMLAdapterBase
 from Products.GenericSetup.utils import exportObjects
 from Products.GenericSetup.utils import importObjects
-from zope.component import adapts
-from zope.component import getSiteManager
-from zope.component import queryMultiAdapter
 
 from ..interfaces import ICachingPolicy
 from ..interfaces import ICachingPolicyManager

--- a/Products/CMFCore/exportimport/catalog.py
+++ b/Products/CMFCore/exportimport/catalog.py
@@ -13,9 +13,10 @@
 """Catalog tool setup handlers.
 """
 
+from zope.component import getSiteManager
+
 from Products.GenericSetup.utils import exportObjects
 from Products.GenericSetup.utils import importObjects
-from zope.component import getSiteManager
 
 from ..interfaces import ICatalogTool
 

--- a/Products/CMFCore/exportimport/content.py
+++ b/Products/CMFCore/exportimport/content.py
@@ -23,13 +23,14 @@ from six import StringIO
 from six.moves.configparser import ConfigParser
 
 from DateTime import DateTime
+from zope.component import getUtility
+from zope.interface import implementer
+from zope.publisher.interfaces.http import MethodNotAllowed
+
 from Products.GenericSetup.content import DAVAwareFileAdapter
 from Products.GenericSetup.content import _globtest
 from Products.GenericSetup.interfaces import IFilesystemExporter
 from Products.GenericSetup.interfaces import IFilesystemImporter
-from zope.component import getUtility
-from zope.interface import implementer
-from zope.publisher.interfaces.http import MethodNotAllowed
 
 from ..interfaces import ITypesTool
 

--- a/Products/CMFCore/exportimport/contenttyperegistry.py
+++ b/Products/CMFCore/exportimport/contenttyperegistry.py
@@ -13,12 +13,13 @@
 """Content type registry xml adapters and setup handlers.
 """
 
+from zope.component import adapts
+from zope.component import getSiteManager
+
 from Products.GenericSetup.interfaces import ISetupEnviron
 from Products.GenericSetup.utils import XMLAdapterBase
 from Products.GenericSetup.utils import exportObjects
 from Products.GenericSetup.utils import importObjects
-from zope.component import adapts
-from zope.component import getSiteManager
 
 from ..interfaces import IContentTypeRegistry
 

--- a/Products/CMFCore/exportimport/cookieauth.py
+++ b/Products/CMFCore/exportimport/cookieauth.py
@@ -13,13 +13,14 @@
 """Cookie crumbler xml adapters and setup handlers.
 """
 
+from zope.component import adapts
+from zope.component import getSiteManager
+
 from Products.GenericSetup.interfaces import ISetupEnviron
 from Products.GenericSetup.utils import PropertyManagerHelpers
 from Products.GenericSetup.utils import XMLAdapterBase
 from Products.GenericSetup.utils import exportObjects
 from Products.GenericSetup.utils import importObjects
-from zope.component import adapts
-from zope.component import getSiteManager
 
 from ..interfaces import ICookieCrumbler
 

--- a/Products/CMFCore/exportimport/mailhost.py
+++ b/Products/CMFCore/exportimport/mailhost.py
@@ -13,10 +13,11 @@
 """Mailhost setup handlers.
 """
 
+from zope.component import getSiteManager
+
 from Products.GenericSetup.utils import exportObjects
 from Products.GenericSetup.utils import importObjects
 from Products.MailHost.interfaces import IMailHost
-from zope.component import getSiteManager
 
 
 def importMailHost(context):

--- a/Products/CMFCore/exportimport/memberdata.py
+++ b/Products/CMFCore/exportimport/memberdata.py
@@ -13,13 +13,14 @@
 """Member data tool xml adapter and setup handlers.
 """
 
+from zope.component import adapts
+from zope.component import getSiteManager
+
 from Products.GenericSetup.interfaces import ISetupEnviron
 from Products.GenericSetup.utils import PropertyManagerHelpers
 from Products.GenericSetup.utils import XMLAdapterBase
 from Products.GenericSetup.utils import exportObjects
 from Products.GenericSetup.utils import importObjects
-from zope.component import adapts
-from zope.component import getSiteManager
 
 from ..interfaces import IMemberDataTool
 

--- a/Products/CMFCore/exportimport/properties.py
+++ b/Products/CMFCore/exportimport/properties.py
@@ -13,12 +13,13 @@
 """Site properties xml adapters and setup handlers.
 """
 
+from zope.component import adapts
+from zope.component import queryMultiAdapter
+
 from Products.GenericSetup.interfaces import IBody
 from Products.GenericSetup.interfaces import ISetupEnviron
 from Products.GenericSetup.utils import PropertyManagerHelpers
 from Products.GenericSetup.utils import XMLAdapterBase
-from zope.component import adapts
-from zope.component import queryMultiAdapter
 
 from ..interfaces import ISiteRoot
 

--- a/Products/CMFCore/exportimport/skins.py
+++ b/Products/CMFCore/exportimport/skins.py
@@ -15,14 +15,15 @@
 
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from zope.component import adapts
+from zope.component import getSiteManager
+
 from Products.GenericSetup.interfaces import ISetupEnviron
 from Products.GenericSetup.utils import NodeAdapterBase
 from Products.GenericSetup.utils import ObjectManagerHelpers
 from Products.GenericSetup.utils import XMLAdapterBase
 from Products.GenericSetup.utils import exportObjects
 from Products.GenericSetup.utils import importObjects
-from zope.component import adapts
-from zope.component import getSiteManager
 
 from ..interfaces import IDirectoryView
 from ..interfaces import ISkinsTool

--- a/Products/CMFCore/exportimport/tests/conformance.py
+++ b/Products/CMFCore/exportimport/tests/conformance.py
@@ -17,8 +17,8 @@
 class ConformsToISimpleItem:
 
     def test_conforms_to_Five_ISimpleItem(self):
-        from zope.interface.verify import verifyClass
         from Products.Five.interfaces import ISimpleItem
+        from zope.interface.verify import verifyClass
 
         verifyClass(ISimpleItem, self._getTargetClass())
 
@@ -27,6 +27,7 @@ class ConformsToIINIAware:
 
     def test_conforms_to_IINIAware(self):
         from zope.interface.verify import verifyClass
+
         from ...interfaces import IINIAware
 
         verifyClass(IINIAware, self._getTargetClass())
@@ -36,6 +37,7 @@ class ConformsToICSVAware:
 
     def test_conforms_to_ICSVAware(self):
         from zope.interface.verify import verifyClass
+
         from ...interfaces import ICSVAware
 
         verifyClass(ICSVAware, self._getTargetClass())
@@ -46,6 +48,7 @@ class ConformsToIFilesystemExporter:
     """
     def test_conforms_to_IFilesystemExporter(self):
         from zope.interface.verify import verifyClass
+
         from ...interfaces import IFilesystemExporter
 
         verifyClass(IFilesystemExporter, self._getTargetClass())
@@ -56,6 +59,7 @@ class ConformsToIFilesystemImporter:
     """
     def test_conforms_to_IFilesystemImporter(self):
         from zope.interface.verify import verifyClass
+
         from ...interfaces import IFilesystemImporter
 
         verifyClass(IFilesystemImporter, self._getTargetClass())

--- a/Products/CMFCore/exportimport/tests/test_actions.py
+++ b/Products/CMFCore/exportimport/tests/test_actions.py
@@ -18,13 +18,14 @@ import unittest
 from Acquisition import Implicit
 from Acquisition import aq_parent
 from OFS.OrderedFolder import OrderedFolder
+from zope.component import getSiteManager
+from zope.interface import implementer
+
 from Products.GenericSetup.testing import BodyAdapterTestCase
 from Products.GenericSetup.testing import NodeAdapterTestCase
 from Products.GenericSetup.tests.common import BaseRegistryTests
 from Products.GenericSetup.tests.common import DummyExportContext
 from Products.GenericSetup.tests.common import DummyImportContext
-from zope.component import getSiteManager
-from zope.interface import implementer
 
 from ...ActionProviderBase import ActionProviderBase
 from ...interfaces import IActionProvider

--- a/Products/CMFCore/exportimport/tests/test_cachingpolicymgr.py
+++ b/Products/CMFCore/exportimport/tests/test_cachingpolicymgr.py
@@ -16,12 +16,13 @@
 import unittest
 
 from OFS.Folder import Folder
+from zope.component import getSiteManager
+
 from Products.GenericSetup.testing import BodyAdapterTestCase
 from Products.GenericSetup.testing import NodeAdapterTestCase
 from Products.GenericSetup.tests.common import BaseRegistryTests
 from Products.GenericSetup.tests.common import DummyExportContext
 from Products.GenericSetup.tests.common import DummyImportContext
-from zope.component import getSiteManager
 
 from ...CachingPolicyManager import CachingPolicyManager
 from ...interfaces import ICachingPolicyManager

--- a/Products/CMFCore/exportimport/tests/test_catalog.py
+++ b/Products/CMFCore/exportimport/tests/test_catalog.py
@@ -19,13 +19,12 @@ from OFS.Folder import Folder
 from Products.GenericSetup.tests.common import BaseRegistryTests
 from Products.GenericSetup.tests.common import DummyExportContext
 from Products.GenericSetup.tests.common import DummyImportContext
-from Testing import ZopeTestCase
-from zope.component import getSiteManager
-
 from Products.ZCTextIndex.Lexicon import CaseNormalizer
 from Products.ZCTextIndex.Lexicon import Splitter
 from Products.ZCTextIndex.Lexicon import StopWordRemover
 from Products.ZCTextIndex.ZCTextIndex import PLexicon
+from Testing import ZopeTestCase
+from zope.component import getSiteManager
 
 from ...CatalogTool import CatalogTool
 from ...interfaces import ICatalogTool

--- a/Products/CMFCore/exportimport/tests/test_catalog.py
+++ b/Products/CMFCore/exportimport/tests/test_catalog.py
@@ -19,12 +19,13 @@ from OFS.Folder import Folder
 from Products.GenericSetup.tests.common import BaseRegistryTests
 from Products.GenericSetup.tests.common import DummyExportContext
 from Products.GenericSetup.tests.common import DummyImportContext
+from Testing import ZopeTestCase
+from zope.component import getSiteManager
+
 from Products.ZCTextIndex.Lexicon import CaseNormalizer
 from Products.ZCTextIndex.Lexicon import Splitter
 from Products.ZCTextIndex.Lexicon import StopWordRemover
 from Products.ZCTextIndex.ZCTextIndex import PLexicon
-from Testing import ZopeTestCase
-from zope.component import getSiteManager
 
 from ...CatalogTool import CatalogTool
 from ...interfaces import ICatalogTool

--- a/Products/CMFCore/exportimport/tests/test_catalog.py
+++ b/Products/CMFCore/exportimport/tests/test_catalog.py
@@ -16,6 +16,9 @@
 import unittest
 
 from OFS.Folder import Folder
+from Testing import ZopeTestCase
+from zope.component import getSiteManager
+
 from Products.GenericSetup.tests.common import BaseRegistryTests
 from Products.GenericSetup.tests.common import DummyExportContext
 from Products.GenericSetup.tests.common import DummyImportContext
@@ -23,8 +26,6 @@ from Products.ZCTextIndex.Lexicon import CaseNormalizer
 from Products.ZCTextIndex.Lexicon import Splitter
 from Products.ZCTextIndex.Lexicon import StopWordRemover
 from Products.ZCTextIndex.ZCTextIndex import PLexicon
-from Testing import ZopeTestCase
-from zope.component import getSiteManager
 
 from ...CatalogTool import CatalogTool
 from ...interfaces import ICatalogTool

--- a/Products/CMFCore/exportimport/tests/test_content.py
+++ b/Products/CMFCore/exportimport/tests/test_content.py
@@ -55,17 +55,16 @@ class SiteStructureExporterTests(unittest.TestCase):
         return obj
 
     def _setUpAdapters(self):
-        from zope.component import provideAdapter
-
-        from Products.GenericSetup.interfaces import IFilesystemExporter
-        from Products.GenericSetup.interfaces import IFilesystemImporter
-        from Products.GenericSetup.interfaces import ICSVAware
-        from Products.GenericSetup.interfaces import IINIAware
-        from ...interfaces import IFolderish
-
-        from ..content import StructureFolderWalkingAdapter
         from Products.GenericSetup.content import CSVAwareFileAdapter
         from Products.GenericSetup.content import INIAwareFileAdapter
+        from Products.GenericSetup.interfaces import ICSVAware
+        from Products.GenericSetup.interfaces import IFilesystemExporter
+        from Products.GenericSetup.interfaces import IFilesystemImporter
+        from Products.GenericSetup.interfaces import IINIAware
+        from zope.component import provideAdapter
+
+        from ...interfaces import IFolderish
+        from ..content import StructureFolderWalkingAdapter
 
         provideAdapter(StructureFolderWalkingAdapter,
                        (IFolderish,),
@@ -558,8 +557,8 @@ class SiteStructureExporterTests(unittest.TestCase):
         self.assertEqual(site.objectIds()[0], 'setup_tool')
 
     def test_import_site_with_subfolders(self):
-        from Products.GenericSetup.tests.test_content \
-            import _PROPERTIES_TEMPLATE
+        from Products.GenericSetup.tests.test_content import \
+            _PROPERTIES_TEMPLATE
         self._setUpAdapters()
         FOLDER_IDS = ('foo', 'bar', 'baz')
 
@@ -586,8 +585,8 @@ class SiteStructureExporterTests(unittest.TestCase):
         self.assertEqual(len(content), len(FOLDER_IDS))
 
     def test_import_site_with_dav_aware_folder(self):
-        from Products.GenericSetup.tests.test_content \
-            import _PROPERTIES_TEMPLATE
+        from Products.GenericSetup.tests.test_content import \
+            _PROPERTIES_TEMPLATE
         self._setUpAdapters()
         FOLDER_IDS = ('foo', 'bar', 'baz')
 
@@ -615,8 +614,8 @@ class SiteStructureExporterTests(unittest.TestCase):
                          KNOWN_DAV % ('Title', 'Description', 'Body'))
 
     def test_import_site_with_dav_aware_folder_with_generic_file_data(self):
-        from Products.GenericSetup.tests.test_content \
-            import _PROPERTIES_TEMPLATE
+        from Products.GenericSetup.tests.test_content import \
+            _PROPERTIES_TEMPLATE
         self._setUpAdapters()
         FOLDER_IDS = ('foo', 'bar', 'baz')
 
@@ -912,9 +911,10 @@ four,five,six
 
 def _makeCSVAware(id):
     from OFS.SimpleItem import SimpleItem
-    from zope.interface import implementer
-    from ...interfaces import IDynamicType
     from Products.GenericSetup.interfaces import ICSVAware
+    from zope.interface import implementer
+
+    from ...interfaces import IDynamicType
 
     @implementer(IDynamicType, ICSVAware)
     class _TestCSVAware(SimpleItem):
@@ -946,9 +946,10 @@ description = %s
 
 def _makeINIAware(id):
     from OFS.SimpleItem import SimpleItem
-    from zope.interface import implementer
-    from ...interfaces import IDynamicType
     from Products.GenericSetup.interfaces import IINIAware
+    from zope.interface import implementer
+
+    from ...interfaces import IDynamicType
 
     @implementer(IDynamicType, IINIAware)
     class _TestINIAware(SimpleItem):
@@ -986,9 +987,10 @@ Description: %s
 
 def _makeDAVAware(id):
     from OFS.SimpleItem import SimpleItem
-    from zope.interface import implementer
-    from ...interfaces import IDynamicType
     from Products.GenericSetup.interfaces import IDAVAware
+    from zope.interface import implementer
+
+    from ...interfaces import IDynamicType
 
     @implementer(IDynamicType, IDAVAware)
     class _TestDAVAware(SimpleItem):
@@ -1019,10 +1021,11 @@ TEST_DAV_FOLDER = 'Test DAV Folder'
 
 
 def _makeDAVAwareFolder(id):
-    from ...PortalFolder import PortalFolder
-    from zope.interface import implementer
-    from ...interfaces import IDynamicType
     from Products.GenericSetup.interfaces import IDAVAware
+    from zope.interface import implementer
+
+    from ...interfaces import IDynamicType
+    from ...PortalFolder import PortalFolder
 
     @implementer(IDynamicType, IDAVAware)
     class _TestDAVAwareFolder(PortalFolder):
@@ -1052,6 +1055,7 @@ TEST_CONTENT = 'Test Content'
 def _makeItem(self):
     from OFS.SimpleItem import SimpleItem
     from zope.interface import implementer
+
     from ...interfaces import IDynamicType
 
     @implementer(IDynamicType)
@@ -1072,8 +1076,8 @@ TEST_FOLDER = 'Test Folder'
 
 def _makeFolder(id, site_folder=False):
     from ...PortalFolder import PortalFolder
-    from ...TypesTool import TypesTool
     from ...tests.base.dummy import DummyType
+    from ...TypesTool import TypesTool
 
     class _TypeInfo(DummyType):
         def _getId(self):

--- a/Products/CMFCore/exportimport/tests/test_content.py
+++ b/Products/CMFCore/exportimport/tests/test_content.py
@@ -20,10 +20,11 @@ from six import StringIO
 from six import binary_type
 from six.moves.configparser import ConfigParser
 
-from Products.GenericSetup.tests.common import DummyExportContext
-from Products.GenericSetup.tests.common import DummyImportContext
 from zope.component import getSiteManager
 from zope.testing.cleanup import cleanUp
+
+from Products.GenericSetup.tests.common import DummyExportContext
+from Products.GenericSetup.tests.common import DummyImportContext
 
 from ...interfaces import ITypesTool
 from ...testing import DummyWorkflow
@@ -55,13 +56,14 @@ class SiteStructureExporterTests(unittest.TestCase):
         return obj
 
     def _setUpAdapters(self):
+        from zope.component import provideAdapter
+
         from Products.GenericSetup.content import CSVAwareFileAdapter
         from Products.GenericSetup.content import INIAwareFileAdapter
         from Products.GenericSetup.interfaces import ICSVAware
         from Products.GenericSetup.interfaces import IFilesystemExporter
         from Products.GenericSetup.interfaces import IFilesystemImporter
         from Products.GenericSetup.interfaces import IINIAware
-        from zope.component import provideAdapter
 
         from ...interfaces import IFolderish
         from ..content import StructureFolderWalkingAdapter
@@ -911,8 +913,9 @@ four,five,six
 
 def _makeCSVAware(id):
     from OFS.SimpleItem import SimpleItem
-    from Products.GenericSetup.interfaces import ICSVAware
     from zope.interface import implementer
+
+    from Products.GenericSetup.interfaces import ICSVAware
 
     from ...interfaces import IDynamicType
 
@@ -946,8 +949,9 @@ description = %s
 
 def _makeINIAware(id):
     from OFS.SimpleItem import SimpleItem
-    from Products.GenericSetup.interfaces import IINIAware
     from zope.interface import implementer
+
+    from Products.GenericSetup.interfaces import IINIAware
 
     from ...interfaces import IDynamicType
 
@@ -987,8 +991,9 @@ Description: %s
 
 def _makeDAVAware(id):
     from OFS.SimpleItem import SimpleItem
-    from Products.GenericSetup.interfaces import IDAVAware
     from zope.interface import implementer
+
+    from Products.GenericSetup.interfaces import IDAVAware
 
     from ...interfaces import IDynamicType
 
@@ -1021,8 +1026,9 @@ TEST_DAV_FOLDER = 'Test DAV Folder'
 
 
 def _makeDAVAwareFolder(id):
-    from Products.GenericSetup.interfaces import IDAVAware
     from zope.interface import implementer
+
+    from Products.GenericSetup.interfaces import IDAVAware
 
     from ...interfaces import IDynamicType
     from ...PortalFolder import PortalFolder

--- a/Products/CMFCore/exportimport/tests/test_contenttyperegistry.py
+++ b/Products/CMFCore/exportimport/tests/test_contenttyperegistry.py
@@ -16,11 +16,12 @@
 import unittest
 
 from OFS.Folder import Folder
+from zope.component import getSiteManager
+
 from Products.GenericSetup.testing import BodyAdapterTestCase
 from Products.GenericSetup.tests.common import BaseRegistryTests
 from Products.GenericSetup.tests.common import DummyExportContext
 from Products.GenericSetup.tests.common import DummyImportContext
-from zope.component import getSiteManager
 
 from ...interfaces import IContentTypeRegistry
 from ...testing import ExportImportZCMLLayer

--- a/Products/CMFCore/exportimport/tests/test_cookieauth.py
+++ b/Products/CMFCore/exportimport/tests/test_cookieauth.py
@@ -16,11 +16,12 @@
 import unittest
 
 from OFS.Folder import Folder
+from zope.component import getSiteManager
+
 from Products.GenericSetup.testing import BodyAdapterTestCase
 from Products.GenericSetup.tests.common import BaseRegistryTests
 from Products.GenericSetup.tests.common import DummyExportContext
 from Products.GenericSetup.tests.common import DummyImportContext
-from zope.component import getSiteManager
 
 from ...CookieCrumbler import CookieCrumbler
 from ...interfaces import ICookieCrumbler

--- a/Products/CMFCore/exportimport/tests/test_mailhost.py
+++ b/Products/CMFCore/exportimport/tests/test_mailhost.py
@@ -16,12 +16,13 @@
 import unittest
 
 from OFS.Folder import Folder
+from Zope2.App import zcml
+from zope.component import getSiteManager
+
 from Products.GenericSetup.tests.common import BaseRegistryTests
 from Products.GenericSetup.tests.common import DummyExportContext
 from Products.GenericSetup.tests.common import DummyImportContext
 from Products.MailHost.interfaces import IMailHost
-from Zope2.App import zcml
-from zope.component import getSiteManager
 
 from ...testing import ExportImportZCMLLayer
 

--- a/Products/CMFCore/exportimport/tests/test_memberdata.py
+++ b/Products/CMFCore/exportimport/tests/test_memberdata.py
@@ -17,11 +17,12 @@ import unittest
 
 from DateTime.DateTime import DateTime
 from OFS.Folder import Folder
+from zope.component import getSiteManager
+
 from Products.GenericSetup.testing import BodyAdapterTestCase
 from Products.GenericSetup.tests.common import BaseRegistryTests
 from Products.GenericSetup.tests.common import DummyExportContext
 from Products.GenericSetup.tests.common import DummyImportContext
-from zope.component import getSiteManager
 
 from ...interfaces import IMemberDataTool
 from ...MemberDataTool import MemberDataTool

--- a/Products/CMFCore/exportimport/tests/test_skins.py
+++ b/Products/CMFCore/exportimport/tests/test_skins.py
@@ -17,14 +17,15 @@ import os
 import unittest
 
 from OFS.Folder import Folder
+from Testing import ZopeTestCase
+from zope.component import getSiteManager
+from zope.interface import implementer
+
 from Products.GenericSetup.testing import BodyAdapterTestCase
 from Products.GenericSetup.testing import NodeAdapterTestCase
 from Products.GenericSetup.tests.common import BaseRegistryTests
 from Products.GenericSetup.tests.common import DummyExportContext
 from Products.GenericSetup.tests.common import DummyImportContext
-from Testing import ZopeTestCase
-from zope.component import getSiteManager
-from zope.interface import implementer
 
 from ...interfaces import ISkinsTool
 from ...testing import ExportImportZCMLLayer

--- a/Products/CMFCore/exportimport/tests/test_typeinfo.py
+++ b/Products/CMFCore/exportimport/tests/test_typeinfo.py
@@ -16,11 +16,12 @@
 import unittest
 
 from OFS.Folder import Folder
+from zope.component import getSiteManager
+
 from Products.GenericSetup.testing import BodyAdapterTestCase
 from Products.GenericSetup.tests.common import BaseRegistryTests
 from Products.GenericSetup.tests.common import DummyExportContext
 from Products.GenericSetup.tests.common import DummyImportContext
-from zope.component import getSiteManager
 
 from ...interfaces import ITypesTool
 from ...permissions import AccessContentsInformation

--- a/Products/CMFCore/exportimport/tests/test_workflow.py
+++ b/Products/CMFCore/exportimport/tests/test_workflow.py
@@ -16,12 +16,13 @@
 import unittest
 
 from OFS.Folder import Folder
+from zope.component import getSiteManager
+from zope.interface import implementer
+
 from Products.GenericSetup.testing import BodyAdapterTestCase
 from Products.GenericSetup.tests.common import BaseRegistryTests
 from Products.GenericSetup.tests.common import DummyExportContext
 from Products.GenericSetup.tests.common import DummyImportContext
-from zope.component import getSiteManager
-from zope.interface import implementer
 
 from ...interfaces import IConfigurableWorkflowTool
 from ...interfaces import IWorkflowTool

--- a/Products/CMFCore/exportimport/typeinfo.py
+++ b/Products/CMFCore/exportimport/typeinfo.py
@@ -13,6 +13,9 @@
 """Types tool xml adapters and setup handlers.
 """
 
+from zope.component import adapts
+from zope.component import getSiteManager
+
 from Products.GenericSetup.interfaces import ISetupEnviron
 from Products.GenericSetup.utils import I18NURI
 from Products.GenericSetup.utils import ObjectManagerHelpers
@@ -20,8 +23,6 @@ from Products.GenericSetup.utils import PropertyManagerHelpers
 from Products.GenericSetup.utils import XMLAdapterBase
 from Products.GenericSetup.utils import exportObjects
 from Products.GenericSetup.utils import importObjects
-from zope.component import adapts
-from zope.component import getSiteManager
 
 from ..interfaces import ITypeInformation
 from ..interfaces import ITypesTool

--- a/Products/CMFCore/exportimport/workflow.py
+++ b/Products/CMFCore/exportimport/workflow.py
@@ -13,14 +13,15 @@
 """Workflow tool xml adapters and setup handlers.
 """
 
+from zope.component import adapts
+from zope.component import getSiteManager
+
 from Products.GenericSetup.interfaces import ISetupEnviron
 from Products.GenericSetup.utils import ObjectManagerHelpers
 from Products.GenericSetup.utils import PropertyManagerHelpers
 from Products.GenericSetup.utils import XMLAdapterBase
 from Products.GenericSetup.utils import exportObjects
 from Products.GenericSetup.utils import importObjects
-from zope.component import adapts
-from zope.component import getSiteManager
 
 from ..interfaces import IConfigurableWorkflowTool
 from ..interfaces import IWorkflowTool

--- a/Products/CMFCore/testing.py
+++ b/Products/CMFCore/testing.py
@@ -14,7 +14,6 @@
 """
 
 from OFS.SimpleItem import SimpleItem
-from Products.GenericSetup.utils import BodyAdapterBase
 from Testing.ZopeTestCase.layer import ZopeLite
 from Zope2.App import zcml
 from zope.component import adapts
@@ -24,6 +23,8 @@ from zope.interface import implementer
 from zope.interface.verify import verifyClass
 from zope.publisher.interfaces.http import IHTTPRequest
 from zope.testing.cleanup import cleanUp
+
+from Products.GenericSetup.utils import BodyAdapterBase
 
 from .interfaces import IWorkflowDefinition
 from .utils import HAS_ZSERVER
@@ -213,11 +214,11 @@ class ExportImportZCMLLayer(ZopeLite):
     def testSetUp(cls):
         import AccessControl
         import Products.Five
-        import Products.GenericSetup
         import Zope2.App
 
         import Products.CMFCore
         import Products.CMFCore.exportimport
+        import Products.GenericSetup
 
         zcml.load_config('meta.zcml', Zope2.App)
         zcml.load_config('meta.zcml', Products.Five)

--- a/Products/CMFCore/testing.py
+++ b/Products/CMFCore/testing.py
@@ -60,12 +60,13 @@ class ConformsToFolder:
 class ConformsToContent:
 
     def test_content_interfaces(self):
+        from Products.GenericSetup.interfaces import IDAVAware
+
         from .interfaces import ICatalogableDublinCore
         from .interfaces import IContentish
         from .interfaces import IDublinCore
         from .interfaces import IDynamicType
         from .interfaces import IMutableDublinCore
-        from Products.GenericSetup.interfaces import IDAVAware
 
         verifyClass(ICatalogableDublinCore, self._getTargetClass())
         verifyClass(IContentish, self._getTargetClass())
@@ -103,6 +104,7 @@ class EventZCMLLayer(ZopeLite):
     @classmethod
     def testSetUp(cls):
         import OFS
+
         import Products
 
         zcml.load_config('meta.zcml', Products.Five)
@@ -209,10 +211,11 @@ class ExportImportZCMLLayer(ZopeLite):
 
     @classmethod
     def testSetUp(cls):
-        import Zope2.App
         import AccessControl
         import Products.Five
         import Products.GenericSetup
+        import Zope2.App
+
         import Products.CMFCore
         import Products.CMFCore.exportimport
 

--- a/Products/CMFCore/tests/test_ActionInformation.py
+++ b/Products/CMFCore/tests/test_ActionInformation.py
@@ -16,10 +16,11 @@
 import unittest
 
 from OFS.Folder import manage_addFolder
-from Products.PythonScripts.PythonScript import manage_addPythonScript
 from zope.component import getSiteManager
 from zope.interface.verify import verifyClass
 from zope.testing.cleanup import cleanUp
+
+from Products.PythonScripts.PythonScript import manage_addPythonScript
 
 from ..Expression import Expression
 from ..Expression import createExprContext

--- a/Products/CMFCore/tests/test_CatalogTool.py
+++ b/Products/CMFCore/tests/test_CatalogTool.py
@@ -154,8 +154,9 @@ class CatalogToolTests(SecurityTest):
         return CatalogDummyContent(*args, **kw)
 
     def test_interfaces(self):
-        from Products.ZCatalog.interfaces import IZCatalog
         from zope.interface.verify import verifyClass
+
+        from Products.ZCatalog.interfaces import IZCatalog
 
         from ..interfaces import IActionProvider
         from ..interfaces import ICatalogTool

--- a/Products/CMFCore/tests/test_CatalogTool.py
+++ b/Products/CMFCore/tests/test_CatalogTool.py
@@ -73,6 +73,7 @@ class IndexableObjectWrapperTests(unittest.TestCase):
 
     def test_interfaces(self):
         from zope.interface.verify import verifyClass
+
         from ..interfaces import IIndexableObjectWrapper
 
         verifyClass(IIndexableObjectWrapper, self._getTargetClass())
@@ -104,8 +105,8 @@ class IndexableObjectWrapperTests(unittest.TestCase):
         self.assertEqual(w.baz, 2)
 
     def test_provided(self):
-        from ..interfaces import IIndexableObjectWrapper
         from ..interfaces import IIndexableObject
+        from ..interfaces import IIndexableObjectWrapper
 
         obj = self._makeContent()
         w = self._makeOne({}, obj)
@@ -115,6 +116,7 @@ class IndexableObjectWrapperTests(unittest.TestCase):
 
     def test_adapts(self):
         from zope.component import adaptedBy
+
         from ..interfaces import ICatalogTool
 
         w = self._getTargetClass()
@@ -152,10 +154,11 @@ class CatalogToolTests(SecurityTest):
         return CatalogDummyContent(*args, **kw)
 
     def test_interfaces(self):
+        from Products.ZCatalog.interfaces import IZCatalog
         from zope.interface.verify import verifyClass
+
         from ..interfaces import IActionProvider
         from ..interfaces import ICatalogTool
-        from Products.ZCatalog.interfaces import IZCatalog
 
         verifyClass(IActionProvider, self._getTargetClass())
         verifyClass(ICatalogTool, self._getTargetClass())
@@ -163,12 +166,14 @@ class CatalogToolTests(SecurityTest):
 
     def loginWithRoles(self, *roles):
         from AccessControl.SecurityManagement import newSecurityManager
+
         from .base.security import UserWithRoles
         user = UserWithRoles(*roles).__of__(self.app)
         newSecurityManager(None, user)
 
     def loginManager(self):
         from AccessControl.SecurityManagement import newSecurityManager
+
         from .base.security import OmnipotentUser
         user = OmnipotentUser().__of__(self.app)
         newSecurityManager(None, user)

--- a/Products/CMFCore/tests/test_CookieCrumbler.py
+++ b/Products/CMFCore/tests/test_CookieCrumbler.py
@@ -54,8 +54,9 @@ class CookieCrumblerTests(unittest.TestCase):
     def setUp(self):
         from zope.component import provideHandler
         from zope.interface.interfaces import IObjectEvent
-        from ..interfaces import ICookieCrumbler
+
         from ..CookieCrumbler import handleCookieCrumblerEvent
+        from ..interfaces import ICookieCrumbler
 
         self._finally = None
 

--- a/Products/CMFCore/tests/test_DirectoryView.py
+++ b/Products/CMFCore/tests/test_DirectoryView.py
@@ -38,8 +38,8 @@ class DirectoryViewPathTests(unittest.TestCase):
     """
 
     def setUp(self):
-        from Products.CMFCore.DirectoryView import registerDirectory
         from Products.CMFCore.DirectoryView import addDirectoryViews
+        from Products.CMFCore.DirectoryView import registerDirectory
         registerDirectory('fake_skins', _globals)
         self.ob = DummyFolder()
         addDirectoryViews(self.ob, 'fake_skins', _globals)
@@ -174,6 +174,7 @@ class DirectoryViewFolderTests(FSDVTest):
 
     def tearDown(self):
         from Products.CMFCore import DirectoryView
+
         # This is nasty, but there is no way to unregister anything
         # right now...
         metatype_registry = DirectoryView._dirreg._meta_types

--- a/Products/CMFCore/tests/test_FSDTMLMethod.py
+++ b/Products/CMFCore/tests/test_FSDTMLMethod.py
@@ -20,10 +20,11 @@ from Acquisition import aq_base
 from App.Common import rfc1123_date
 from DateTime import DateTime
 from OFS.Folder import Folder
-from Products.StandardCacheManagers import RAMCacheManager
 from zope.component import getSiteManager
 from zope.component.hooks import setHooks
 from zope.testing.cleanup import cleanUp
+
+from Products.StandardCacheManagers import RAMCacheManager
 
 from ..FSMetadata import FSMetadata
 from ..interfaces import ICachingPolicyManager

--- a/Products/CMFCore/tests/test_FSPageTemplate.py
+++ b/Products/CMFCore/tests/test_FSPageTemplate.py
@@ -18,11 +18,12 @@ from os.path import join as path_join
 
 from Acquisition import aq_base
 from OFS.Folder import Folder
-from Products.StandardCacheManagers import RAMCacheManager
 from Testing import ZopeTestCase
 from zope.component import getSiteManager
 from zope.tales.tales import Undefined
 from zope.testing.cleanup import cleanUp
+
+from Products.StandardCacheManagers import RAMCacheManager
 
 from ..FSMetadata import FSMetadata
 from ..interfaces import ICachingPolicyManager

--- a/Products/CMFCore/tests/test_FSPythonScript.py
+++ b/Products/CMFCore/tests/test_FSPythonScript.py
@@ -26,9 +26,10 @@ from Acquisition import aq_base
 from DateTime.DateTime import DateTime
 from OFS.Folder import Folder
 from OFS.SimpleItem import SimpleItem
-from Products.StandardCacheManagers import RAMCacheManager
 from Testing import ZopeTestCase
 from zope.testing.cleanup import cleanUp
+
+from Products.StandardCacheManagers import RAMCacheManager
 
 from ..FSMetadata import FSMetadata
 from ..FSPythonScript import FSPythonScript

--- a/Products/CMFCore/tests/test_FSReSTMethod.py
+++ b/Products/CMFCore/tests/test_FSReSTMethod.py
@@ -163,6 +163,7 @@ class FSReSTMethodCustomizationTests(SecurityTest, FSReSTMaker):
 
     def test_customize(self):
         from Products.PageTemplates.ZopePageTemplate import ZopePageTemplate
+
         from ..FSReSTMethod import _CUSTOMIZED_TEMPLATE_ZPT
 
         self.custom.all_meta_types = ZPT_META_TYPES

--- a/Products/CMFCore/tests/test_FSSTXMethod.py
+++ b/Products/CMFCore/tests/test_FSSTXMethod.py
@@ -87,8 +87,9 @@ class _TemplateSwitcher:
         FSSTXMaker.tearDown(self)
 
     def _setWhichTemplate(self, which):
-        from .. import FSSTXMethod
         from Products.PageTemplates.ZopePageTemplate import ZopePageTemplate
+
+        from .. import FSSTXMethod
         FSSTXMethod._STX_TEMPLATE = which
 
         if which == 'DTML':
@@ -225,6 +226,7 @@ class FSSTXMethodCustomizationTests(SecurityTest,
 
     def test_customize_with_DTML(self):
         from OFS.DTMLDocument import DTMLDocument
+
         from ..FSSTXMethod import _CUSTOMIZED_TEMPLATE_DTML
 
         self._setWhichTemplate('DTML')
@@ -245,6 +247,7 @@ class FSSTXMethodCustomizationTests(SecurityTest,
 
     def test_customize_with_ZPT(self):
         from Products.PageTemplates.ZopePageTemplate import ZopePageTemplate
+
         from ..FSSTXMethod import _CUSTOMIZED_TEMPLATE_ZPT
 
         self._setWhichTemplate('ZPT')

--- a/Products/CMFCore/tests/test_MemberDataTool.py
+++ b/Products/CMFCore/tests/test_MemberDataTool.py
@@ -95,6 +95,7 @@ class MemberDataToolTests(unittest.TestCase):
     def test_pruneMemberData(self):
         # This needs a tad more setup
         from OFS.Folder import Folder
+
         from ..MembershipTool import MembershipTool
         folder = Folder('test')
         folder._setObject('portal_memberdata', self._makeOne())
@@ -135,6 +136,7 @@ class MemberAdapterTests(unittest.TestCase):
 
     def setUp(self):
         from OFS.Folder import Folder
+
         from ..MemberDataTool import MemberDataTool
         from ..MembershipTool import MembershipTool
 
@@ -149,6 +151,7 @@ class MemberAdapterTests(unittest.TestCase):
 
     def test_interfaces(self):
         from AccessControl.interfaces import IUser
+
         from ..interfaces import IMember
         from ..interfaces import IMemberData
 

--- a/Products/CMFCore/tests/test_PortalFolder.py
+++ b/Products/CMFCore/tests/test_PortalFolder.py
@@ -973,7 +973,9 @@ class PortalFolderCopySupportTests(SecurityTest):
 
     def _assertCopyErrorUnauth(self, callable, *args, **kw):
         import re
+
         from OFS.CopySupport import CopyError
+
         from ..exceptions import zExceptions_Unauthorized
 
         ce_regex = kw.get('ce_regex')
@@ -1127,6 +1129,7 @@ class PortalFolderCopySupportTests(SecurityTest):
 
     def test_move_cant_delete_source(self):
         from AccessControl.Permissions import delete_objects as DeleteObjects
+
         from ..PortalFolder import PortalFolder
 
         folder1, folder2 = self._initFolders()

--- a/Products/CMFCore/tests/test_TypesTool.py
+++ b/Products/CMFCore/tests/test_TypesTool.py
@@ -36,26 +36,31 @@ class TypesToolTests(unittest.TestCase):
 
     def test_class_conforms_to_IActionProvider(self):
         from zope.interface.verify import verifyClass
+
         from ..interfaces import IActionProvider
         verifyClass(IActionProvider, self._getTargetClass())
 
     def test_instance_conforms_to_IActionProvider(self):
         from zope.interface.verify import verifyObject
+
         from ..interfaces import IActionProvider
         verifyObject(IActionProvider, self._makeOne())
 
     def test_class_conforms_to_ITypesTool(self):
         from zope.interface.verify import verifyClass
+
         from ..interfaces import IActionProvider
         verifyClass(IActionProvider, self._getTargetClass())
 
     def test_instance_conforms_to_ITypesTool(self):
         from zope.interface.verify import verifyObject
+
         from ..interfaces import IActionProvider
         verifyObject(IActionProvider, self._makeOne())
 
     def test_listActions_passes_all_context_information_to_TIs(self):
         from zope.interface import implementer
+
         from ..interfaces import ITypeInformation
         from .base.dummy import DummyContent
 
@@ -100,6 +105,7 @@ class TypesToolFunctionalTests(SecurityTest):
     def test_allMetaTypes(self):
         # all typeinfo's returned by allMetaTypes can be traversed to.
         from Acquisition import aq_base
+
         from ..interfaces import ITypeInformation
         if HAS_ZSERVER:
             from webdav.NullResource import NullResource
@@ -124,6 +130,7 @@ class TypesToolFunctionalTests(SecurityTest):
     def test_constructContent_simple_FTI(self):
         from AccessControl.SecurityManagement import newSecurityManager
         from AccessControl.SecurityManager import setSecurityPolicy
+
         from ..TypesTool import FactoryTypeInformation as FTI
         from .base.dummy import DummyFolder
         from .base.tidata import FTIDATA_DUMMY
@@ -143,6 +150,7 @@ class TypesToolFunctionalTests(SecurityTest):
     def test_constructContent_FTI_w_wftool_no_workflows(self):
         from AccessControl.SecurityManagement import newSecurityManager
         from AccessControl.SecurityManager import setSecurityPolicy
+
         from ..TypesTool import FactoryTypeInformation as FTI
         from .base.dummy import DummyFolder
         from .base.tidata import FTIDATA_DUMMY
@@ -163,6 +171,7 @@ class TypesToolFunctionalTests(SecurityTest):
     def test_constructContent_FTI_w_wftool_w_workflow_no_guard(self):
         from AccessControl.SecurityManagement import newSecurityManager
         from AccessControl.SecurityManager import setSecurityPolicy
+
         from ..TypesTool import FactoryTypeInformation as FTI
         from .base.dummy import DummyFolder
         from .base.tidata import FTIDATA_DUMMY
@@ -183,6 +192,7 @@ class TypesToolFunctionalTests(SecurityTest):
     def test_constructContent_FTI_w_wftool_w_workflow_w_guard_allows(self):
         from AccessControl.SecurityManagement import newSecurityManager
         from AccessControl.SecurityManager import setSecurityPolicy
+
         from ..TypesTool import FactoryTypeInformation as FTI
         from .base.dummy import DummyFolder
         from .base.tidata import FTIDATA_DUMMY
@@ -204,6 +214,7 @@ class TypesToolFunctionalTests(SecurityTest):
         from AccessControl import Unauthorized
         from AccessControl.SecurityManagement import newSecurityManager
         from AccessControl.SecurityManager import setSecurityPolicy
+
         from ..TypesTool import FactoryTypeInformation as FTI
         from .base.dummy import DummyFolder
         from .base.tidata import FTIDATA_DUMMY
@@ -228,11 +239,12 @@ class TypesToolFunctionalTests(SecurityTest):
         from AccessControl import Unauthorized
         from AccessControl.SecurityManagement import newSecurityManager
         from AccessControl.SecurityManager import setSecurityPolicy
+        from Products.PythonScripts.PythonScript import PythonScript
+
         from ..PortalFolder import PortalFolder
         from ..TypesTool import ScriptableTypeInformation as STI
         from .base.dummy import DummyFactoryDispatcher
         from .base.tidata import STI_SCRIPT
-        from Products.PythonScripts.PythonScript import PythonScript
         site = self._makeSite().__of__(self.app)
         acl_users = site.acl_users
         setSecurityPolicy(self._oldPolicy)
@@ -273,11 +285,13 @@ class TypeInfoTests(object):
 
     def test_class_conforms_to_ITypeInformation(self):
         from zope.interface.verify import verifyClass
+
         from ..interfaces import ITypeInformation
         verifyClass(ITypeInformation, self._getTargetClass())
 
     def test_instance_conforms_to_ITypeInformation(self):
         from zope.interface.verify import verifyObject
+
         from ..interfaces import ITypeInformation
         verifyObject(ITypeInformation, self._makeOne())
 
@@ -563,6 +577,7 @@ class FTIConstructionTestCase:
 
     def test_isConstructionAllowed_for_Omnipotent(self):
         from AccessControl.SecurityManagement import newSecurityManager
+
         from .base.security import OmnipotentUser
         newSecurityManager(None, OmnipotentUser().__of__(self.f))
         self.assertTrue(self.ti.isConstructionAllowed(self.f))
@@ -572,6 +587,7 @@ class FTIConstructionTestCase:
 
     def test_isConstructionAllowed_wo_Role(self):
         from AccessControl.SecurityManagement import newSecurityManager
+
         from .base.security import UserWithRoles
         newSecurityManager(None, UserWithRoles('FooViewer').__of__(self.f))
         self.assertFalse(self.ti.isConstructionAllowed(self.f))
@@ -583,6 +599,7 @@ class FTIConstructionTestCase:
     def test_constructInstance_wo_Roles(self):
         from AccessControl.SecurityManagement import newSecurityManager
         from AccessControl.unauthorized import Unauthorized
+
         from .base.security import UserWithRoles
         newSecurityManager(None, UserWithRoles('FooViewer').__of__(self.f))
         self.assertRaises(Unauthorized,
@@ -595,6 +612,7 @@ class FTIConstructionTestCase:
 
     def test_constructInstance_private(self):
         from AccessControl.SecurityManagement import newSecurityManager
+
         from .base.security import UserWithRoles
         newSecurityManager(None, UserWithRoles('NotAFooAdder').__of__(self.f))
         self.ti._constructInstance(self.f, 'foo')
@@ -623,6 +641,7 @@ class FTIOldstyleConstructionTests(FTIConstructionTestCase, unittest.TestCase):
 
     def setUp(self):
         from AccessControl.SecurityManagement import newSecurityManager
+
         from .base.dummy import DummyFolder
         from .base.security import UserWithRoles
 
@@ -698,6 +717,7 @@ class FTINewstyleConstructionTests(FTIConstructionTestCase, SecurityTest):
     def setUp(self):
         from AccessControl.SecurityManagement import newSecurityManager
         from zope.component.interfaces import IFactory
+
         from .base.dummy import DummyFactory
         from .base.dummy import DummyFolder
         from .base.security import UserWithRoles

--- a/Products/CMFCore/tests/test_TypesTool.py
+++ b/Products/CMFCore/tests/test_TypesTool.py
@@ -239,6 +239,7 @@ class TypesToolFunctionalTests(SecurityTest):
         from AccessControl import Unauthorized
         from AccessControl.SecurityManagement import newSecurityManager
         from AccessControl.SecurityManager import setSecurityPolicy
+
         from Products.PythonScripts.PythonScript import PythonScript
 
         from ..PortalFolder import PortalFolder

--- a/Products/CMFCore/tests/test_utils.py
+++ b/Products/CMFCore/tests/test_utils.py
@@ -71,8 +71,8 @@ class CoreUtilsTests(unittest.TestCase):
                              ['foo', 'bar', 'baz'])
 
     def test_getPackageName(self):
-        from ..utils import getPackageName
         from ..utils import _globals
+        from ..utils import getPackageName
 
         self.assertEqual(getPackageName(globals()), 'Products.CMFCore.tests')
         self.assertEqual(getPackageName(_globals), 'Products.CMFCore')
@@ -162,9 +162,10 @@ class CoreUtilsSecurityTests(SecurityTest):
 
     def _makeSite(self):
         from OFS.owner import Owned
+
+        from .base.dummy import DummyObject
         from .base.dummy import DummySite
         from .base.dummy import DummyUserFolder
-        from .base.dummy import DummyObject
 
         class _DummyObject(Owned, DummyObject):
             pass
@@ -182,6 +183,7 @@ class CoreUtilsSecurityTests(SecurityTest):
         from AccessControl.Permission import Permission
         from AccessControl.SecurityManagement import newSecurityManager
         from AccessControl.SecurityManager import setSecurityPolicy
+
         from ..utils import _checkPermission
 
         setSecurityPolicy(ZopeSecurityPolicy())
@@ -213,8 +215,8 @@ class CoreUtilsSecurityTests(SecurityTest):
         # actual local role settings and it was possible to manipulate them
         # by changing the return value.
         # http://www.zope.org/Collectors/CMF/376 (FIXME: broken link)
-        from .base.dummy import DummyContent
         from ..utils import _mergedLocalRoles
+        from .base.dummy import DummyContent
         obj = DummyContent()
         obj.manage_addLocalRoles('dummyuser1', ['Manager', 'Owner'])
         self.assertEqual(len(obj.get_local_roles_for_userid('dummyuser1')), 2)
@@ -246,6 +248,7 @@ class CoreUtilsSecurityTests(SecurityTest):
         from AccessControl.Permission import Permission
         from AccessControl.SecurityManagement import newSecurityManager
         from AccessControl.SecurityManager import setSecurityPolicy
+
         from ..utils import FakeExecutableObject
 
         setSecurityPolicy(ZopeSecurityPolicy())

--- a/Products/CMFCore/utils.py
+++ b/Products/CMFCore/utils.py
@@ -21,10 +21,10 @@ from os import path as os_path
 from os.path import abspath
 from warnings import warn
 
+import pkg_resources
 import six
 from six.moves._thread import allocate_lock
 
-import pkg_resources
 from AccessControl.class_init import InitializeClass
 from AccessControl.Permission import Permission
 from AccessControl.PermissionRole import rolesForPermissionOn

--- a/Products/CMFCore/utils.py
+++ b/Products/CMFCore/utils.py
@@ -21,11 +21,10 @@ from os import path as os_path
 from os.path import abspath
 from warnings import warn
 
-import pkg_resources
 import six
 from six.moves._thread import allocate_lock
 
-import Products
+import pkg_resources
 from AccessControl.class_init import InitializeClass
 from AccessControl.Permission import Permission
 from AccessControl.PermissionRole import rolesForPermissionOn
@@ -54,6 +53,8 @@ from zope.component import queryUtility
 from zope.dottedname.resolve import resolve as resolve_dotted_name
 from zope.i18nmessageid import MessageFactory
 from zope.interface.interfaces import ComponentLookupError
+
+import Products
 
 from .exceptions import AccessControl_Unauthorized
 from .exceptions import NotFound

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ universal = 1
 force_single_line = True
 combine_as_imports = True
 sections = FUTURE,STDLIB,THIRDPARTY,ZOPE,FIRSTPARTY,LOCALFOLDER
-known_third_party = six, docutils
+known_third_party = six, docutils, pkg_resources
 default_section = ZOPE
 known_zope =
     Products.PageTemplates

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,21 +15,10 @@ force_single_line = True
 combine_as_imports = True
 sections = FUTURE,STDLIB,THIRDPARTY,ZOPE,FIRSTPARTY,LOCALFOLDER
 known_third_party = six, docutils
-known_zope =
-    Products.PageTemplates,
-    zope.component,
-    zope.interface,
-    Products.BTreeFolder2,
-    Products.ZCatalog,
-    Products.PluginIndexes,
-    Products.PythonScripts,
-    Products.Five,
-    Products.GenericSetup,
-    Products.MailHost,
-    Products.StandardCacheManagers,
-    Products.ZCTextIndex,
-
 default_section = ZOPE
+known_zope =
+    Products.PageTemplates
+    Products.Five
 line_length = 79
 lines_after_imports = 2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,19 @@ force_single_line = True
 combine_as_imports = True
 sections = FUTURE,STDLIB,THIRDPARTY,ZOPE,FIRSTPARTY,LOCALFOLDER
 known_third_party = six, docutils
+known_zope =
+    Products.PageTemplates,
+    zope.component,
+    zope.interface,
+    Products.BTreeFolder2,
+    Products.ZCatalog,
+    Products.PluginIndexes,
+    Products.PythonScripts,
+    Products.Five,
+    Products.GenericSetup,
+    Products.MailHost,
+    Products.StandardCacheManagers,
+
 default_section = ZOPE
 line_length = 79
 lines_after_imports = 2

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,8 +18,6 @@ known_third_party = six, docutils
 default_section = ZOPE
 line_length = 79
 lines_after_imports = 2
-not_skip =
-    __init__.py
 
 [flake8]
 no-accept-encodings = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ known_zope =
     Products.GenericSetup,
     Products.MailHost,
     Products.StandardCacheManagers,
+    Products.ZCTextIndex,
 
 default_section = ZOPE
 line_length = 79

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ basepython = python3
 commands_pre =
     mkdir -p {toxinidir}/parts/flake8
 commands =
-    - isort --check-only --diff --recursive {toxinidir}/Products setup.py
+    - isort --check-only --diff {toxinidir}/Products setup.py
     - flake8 --format=html Products setup.py
     flake8 Products setup.py
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,6 @@ deps =
     flake8-debugger
     # flake8-deprecated
     # flake8-todo
-    flake8-isort
     mccabe
     flake8-blind-except
     flake8-commas


### PR DESCRIPTION
Please have a close look, especially at the `known_zope` section in the `setup.cfg`, as I am not sure what is regarded part of Zope and what is a third party package.