### PR TITLE
set Cache-Control header in 304 Not Modified response case as well.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Products.CMFCore Changelog
 2.5.2 (unreleased)
 ------------------
 
+- Set Cache-Control header in '304 Not Modified' response case as well.
+  (`#111 <https://github.com/zopefoundation/Products.CMFCore/issues/111>`_)
 
 2.5.1 (2021-03-12)
 ------------------

--- a/src/Products/CMFCore/FSDTMLMethod.py
+++ b/src/Products/CMFCore/FSDTMLMethod.py
@@ -125,6 +125,8 @@ class FSDTMLMethod(RestrictedDTML, RoleManager, FSObject, HTML):
 
         if client is not None:
             if _checkConditionalGET(self, kw):
+                # caching policy manager hook
+                _setCacheHeaders(self, {})
                 return ''
 
         if not self._cache_namespace_keys:

--- a/src/Products/CMFCore/FSFile.py
+++ b/src/Products/CMFCore/FSFile.py
@@ -155,6 +155,14 @@ class FSFile(FSObject):
         self._updateFromFS()
         view = _ViewEmulator().__of__(self)
 
+        # There are 2 Cache Managers which can be in play....
+        # need to decide which to use to determine where the cache headers
+        # are decided on.
+        if self.ZCacheable_getManager() is not None:
+            self.ZCacheable_set(None)
+        else:
+            _setCacheHeaders(view, extra_context={})
+
         # If we have a conditional get, set status 304 and return
         # no content
         if _checkConditionalGET(view, extra_context={}):
@@ -171,14 +179,6 @@ class FSFile(FSObject):
         data = self._readFile(0)
         data_len = len(data)
         RESPONSE.setHeader('Content-Length', data_len)
-
-        # There are 2 Cache Managers which can be in play....
-        # need to decide which to use to determine where the cache headers
-        # are decided on.
-        if self.ZCacheable_getManager() is not None:
-            self.ZCacheable_set(None)
-        else:
-            _setCacheHeaders(view, extra_context={})
         return data
 
     def _setOldCacheHeaders(self):

--- a/src/Products/CMFCore/FSImage.py
+++ b/src/Products/CMFCore/FSImage.py
@@ -111,6 +111,14 @@ class FSImage(FSObject):
         self._updateFromFS()
         view = _ViewEmulator().__of__(self)
 
+        # There are 2 Cache Managers which can be in play....
+        # need to decide which to use to determine where the cache headers
+        # are decided on.
+        if self.ZCacheable_getManager() is not None:
+            self.ZCacheable_set(None)
+        else:
+            _setCacheHeaders(view, extra_context={})
+
         # If we have a conditional get, set status 304 and return
         # no content
         if _checkConditionalGET(view, extra_context={}):
@@ -127,14 +135,6 @@ class FSImage(FSObject):
         data = self._readFile(0)
         data_len = len(data)
         RESPONSE.setHeader('Content-Length', data_len)
-
-        # There are 2 Cache Managers which can be in play....
-        # need to decide which to use to determine where the cache headers
-        # are decided on.
-        if self.ZCacheable_getManager() is not None:
-            self.ZCacheable_set(None)
-        else:
-            _setCacheHeaders(view, extra_context={})
         return data
 
     def _setOldCacheHeaders(self):

--- a/src/Products/CMFCore/FSPageTemplate.py
+++ b/src/Products/CMFCore/FSPageTemplate.py
@@ -191,6 +191,7 @@ class FSPageTemplate(FSObject, Script, PageTemplate):
             # If we have a conditional get, set status 304 and return
             # no content
             if _checkConditionalGET(self, extra_context):
+                _setCacheHeaders(self, extra_context)
                 return ''
 
         result = FSPageTemplate.inheritedAttribute('pt_render')(

--- a/src/Products/CMFCore/FSReSTMethod.py
+++ b/src/Products/CMFCore/FSReSTMethod.py
@@ -162,10 +162,10 @@ class FSReSTMethod(FSObject):
             RESPONSE.setHeader('Content-Type', 'text/html')
 
         view = _ViewEmulator(self.getId()).__of__(self)
+        _setCacheHeaders(view, extra_context={})
+
         if _checkConditionalGET(view, extra_context={}):
             return ''
-
-        _setCacheHeaders(view, extra_context={})
 
         return self._render(REQUEST, RESPONSE, **kw)
 

--- a/src/Products/CMFCore/FSSTXMethod.py
+++ b/src/Products/CMFCore/FSSTXMethod.py
@@ -156,10 +156,10 @@ class FSSTXMethod(FSObject):
             RESPONSE.setHeader('Content-Type', 'text/html')
 
         view = _ViewEmulator(self.getId()).__of__(self)
+        _setCacheHeaders(view, extra_context={})
+
         if _checkConditionalGET(view, extra_context={}):
             return ''
-
-        _setCacheHeaders(view, extra_context={})
 
         return self._render(REQUEST, RESPONSE, **kw)
 

--- a/src/Products/CMFCore/tests/test_CachingPolicyManager.py
+++ b/src/Products/CMFCore/tests/test_CachingPolicyManager.py
@@ -708,6 +708,7 @@ class CachingPolicyManager304Tests(SecurityTest, FSDVTest):
         request.environ['HTTP_AUTHORIZATION'] = self.auth_header
         doc1()
         self.assertEqual(response.getStatus(), 304)
+        self.assertNotEqual(response.getHeader('cache-control'), None)
         self._cleanup()
 
         # ETag handling is not enabled in the policy for doc1, so asking for
@@ -767,6 +768,7 @@ class CachingPolicyManager304Tests(SecurityTest, FSDVTest):
         request.environ['HTTP_AUTHORIZATION'] = self.auth_header
         doc2()
         self.assertEqual(response.getStatus(), 304)
+        self.assertNotEqual(response.getHeader('cache-control'), None)
         self._cleanup()
 
         # We specify an ETag and a modification time condition that dooes not
@@ -795,6 +797,7 @@ class CachingPolicyManager304Tests(SecurityTest, FSDVTest):
         request.environ['HTTP_AUTHORIZATION'] = self.auth_header
         doc2()
         self.assertEqual(response.getStatus(), 304)
+        self.assertNotEqual(response.getHeader('cache-control'), None)
         self._cleanup()
 
     def testConditionalGETDisabled(self):

--- a/src/Products/CMFCore/tests/test_FSDTMLMethod.py
+++ b/src/Products/CMFCore/tests/test_FSDTMLMethod.py
@@ -113,6 +113,8 @@ class FSDTMLMethodTests(TransactionalTest, FSDTMLMaker):
 
         self.assertEqual(data, '')
         self.assertEqual(self.RESPONSE.getStatus(), 304)
+        self.assertNotEqual(self.RESPONSE.getHeader('x-cache-headers-set-by'),
+                            None)
 
 
 class FSDTMLMethodCustomizationTests(SecurityTest, FSDTMLMaker):

--- a/src/Products/CMFCore/tests/test_FSFile.py
+++ b/src/Products/CMFCore/tests/test_FSFile.py
@@ -190,6 +190,8 @@ class FSFileTests(TransactionalTest, FSDVTest):
         data = file.index_html(self.REQUEST, self.RESPONSE)
         self.assertEqual(len(data), 0)
         self.assertEqual(self.RESPONSE.getStatus(), 304)
+        self.assertNotEqual(self.RESPONSE.getHeader('x-cache-headers-set-by'),
+                            None)
 
     def test_index_html_200_with_cpm(self):
         # should behave the same as without cpm installed

--- a/src/Products/CMFCore/tests/test_FSImage.py
+++ b/src/Products/CMFCore/tests/test_FSImage.py
@@ -132,6 +132,8 @@ class FSImageTests(TransactionalTest, FSDVTest):
         data = file.index_html(self.REQUEST, self.RESPONSE)
         self.assertEqual(len(data), 0)
         self.assertEqual(self.RESPONSE.getStatus(), 304)
+        self.assertNotEqual(self.RESPONSE.getHeader('x-cache-headers-set-by'),
+                            None)
 
     def test_index_html_200_with_cpm(self):
         # should behave the same as without cpm installed

--- a/src/Products/CMFCore/tests/test_FSReSTMethod.py
+++ b/src/Products/CMFCore/tests/test_FSReSTMethod.py
@@ -140,6 +140,8 @@ class FSReSTMethodTests(TransactionalTest, FSReSTMaker):
 
         self.assertEqual(data, '')
         self.assertEqual(self.RESPONSE.getStatus(), 304)
+        self.assertNotEqual(self.RESPONSE.getHeader('x-cache-headers-set-by'),
+                            None)
 
 
 ADD_ZPT = 'Add page templates'

--- a/src/Products/CMFCore/tests/test_FSSTXMethod.py
+++ b/src/Products/CMFCore/tests/test_FSSTXMethod.py
@@ -168,6 +168,8 @@ class FSSTXMethodTests(TransactionalTest, FSSTXMaker, _TemplateSwitcher):
 
         self.assertEqual(data, '')
         self.assertEqual(self.RESPONSE.getStatus(), 304)
+        self.assertNotEqual(self.RESPONSE.getHeader('x-cache-headers-set-by'),
+                            None)
 
 
 ADD_ZPT = 'Add page templates'


### PR DESCRIPTION
Currently, responses of several CMFCore types do not have Cache-Control header based on Caching Policy Manager in '304 Not Modified' response case. Imagine the following scenario with intermediate cache server (like Apache Traffic Server) : 

* intermediate cache server fetches from Zope and store it in its cache.
* we modify Caching Policy Manager configuration.
* intermediate cache server tries to revalidate its cache with 'If-Modified-Since' header.
* Zope responses '304 Not Modified' with the same Last-Modified value but without (updated) Cache-Control header.
* intermediate cache server does not (cannot) update its cache with updated cache configuration.

Thus cache inside intermediate cache server can stay forever, unless Zope returns a different Last-Modified value.

[RFC 7232](https://tools.ietf.org/html/rfc7232#section-4.1) says :

>   The server generating a 304 response MUST generate any of the
>   following header fields that would have been sent in a 200 (OK)
>   response to the same request: Cache-Control, Content-Location, Date,
>   ETag, Expires, and Vary.

With this PR, `_setCacheHeaders` is called before returning '304 Not Modified' so that intermediate cache can update its cache with updated Caching Policy Manager configuration.