### PR TITLE
Prevent `AttributeError` when using `subscribers.zcml`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Products.CMFCore Changelog
 2.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not break at startup when ``subscribers.zcml`` is included but no
+  ``portal_catalog`` object is in the database, e. g. when starting for the
+  first time.
+  (`#115 <https://github.com/zopefoundation/Products.CMFCore/pull/115>`_)
 
 
 2.5.2 (2021-06-24)
@@ -17,6 +20,7 @@ Products.CMFCore Changelog
 
 - Set Cache-Control header in '304 Not Modified' response case as well.
   (`#111 <https://github.com/zopefoundation/Products.CMFCore/issues/111>`_)
+
 
 2.5.1 (2021-03-12)
 ------------------

--- a/src/Products/CMFCore/indexing.py
+++ b/src/Products/CMFCore/indexing.py
@@ -40,7 +40,8 @@ class PortalCatalogProcessor(object):
 
     def index(self, obj, attributes=None):
         catalog = getToolByName(obj, 'portal_catalog', None)
-        catalog._indexObject(obj)
+        if catalog is not None:
+            catalog._indexObject(obj)
 
     def reindex(self, obj, attributes=None, update_metadata=1):
         catalog = getToolByName(obj, 'portal_catalog', None)


### PR DESCRIPTION
When including `subscribers.zcml` I get the following traceback when there is no `portal_catalog`.

```python
$ bin/runwsgi etc/zope.ini
2021-06-30 14:33:17 INFO [chameleon.config:38][MainThread] directory cache: .../var/cache.
Traceback (most recent call last):
  File "bin/runwsgi", line 8, in <module>
    sys.exit(main())
  File ".../lib/python3.7/site-packages/Zope2/Startup/serve.py", line 251, in main
    return command.run()
  File ".../lib/python3.7/site-packages/Zope2/Startup/serve.py", line 190, in run
    global_conf=vars)
  File ".../lib/python3.7/site-packages/Zope2/Startup/serve.py", line 220, in loadapp
    return loadapp(app_spec, name=name, relative_to=relative_to, **kw)
  File ".../lib/python3.7/site-packages/paste/deploy/loadwsgi.py", line 253, in loadapp
    return loadobj(APP, uri, name=name, **kw)
  File ".../lib/python3.7/site-packages/paste/deploy/loadwsgi.py", line 278, in loadobj
    return context.create()
  File ".../lib/python3.7/site-packages/paste/deploy/loadwsgi.py", line 715, in create
    return self.object_type.invoke(self)
  File ".../lib/python3.7/site-packages/paste/deploy/loadwsgi.py", line 209, in invoke
    app = context.app_context.create()
  File ".../lib/python3.7/site-packages/paste/deploy/loadwsgi.py", line 715, in create
    return self.object_type.invoke(self)
  File ".../lib/python3.7/site-packages/paste/deploy/loadwsgi.py", line 152, in invoke
    return fix_call(context.object, context.global_conf, **context.local_conf)
  File ".../lib/python3.7/site-packages/paste/deploy/util.py", line 55, in fix_call
    val = callable(*args, **kw)
  File ".../lib/python3.7/site-packages/Zope2/Startup/run.py", line 61, in make_wsgi_app
    starter.prepare()
  File ".../lib/python3.7/site-packages/Zope2/Startup/starter.py", line 38, in prepare
    self.startZope()
  File ".../lib/python3.7/site-packages/Zope2/Startup/starter.py", line 94, in startZope
    Zope2.startup_wsgi()
  File ".../lib/python3.7/site-packages/Zope2/__init__.py", line 36, in startup_wsgi
    _startup()
  File ".../lib/python3.7/site-packages/Zope2/App/startup.py", line 131, in startup
    DB, 'Application', OFS.Application.Application)
  File ".../lib/python3.7/site-packages/App/ZApplication.py", line 31, in __init__
    conn.transaction_manager.commit()
  File ".../lib/python3.7/site-packages/transaction/_manager.py", line 134, in commit
    return self.get().commit()
  File ".../lib/python3.7/site-packages/transaction/_transaction.py", line 267, in commit
    self._callBeforeCommitHooks()
  File ".../lib/python3.7/site-packages/transaction/_transaction.py", line 333, in _callBeforeCommitHooks
    self._call_hooks(self._before_commit)
  File ".../lib/python3.7/site-packages/transaction/_transaction.py", line 372, in _call_hooks
    hook(*(prefix_args + args), **kws)
  File ".../lib/python3.7/site-packages/Products/CMFCore/indexing.py", line 316, in before_commit
    self.queue.process()
  File ".../lib/python3.7/site-packages/Products/CMFCore/indexing.py", line 224, in process
    util.index(obj, attributes)
  File ".../lib/python3.7/site-packages/Products/CMFCore/indexing.py", line 43, in index
    catalog._indexObject(obj)
AttributeError: 'NoneType' object has no attribute '_indexObject'
```

I added a check for the existence of `portal_catalog` as it its done in `reindex` and `unindex`.