### PR TITLE
Add support for Python 3.10 + fix docs + fix lint.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,15 +20,16 @@ jobs:
         - ubuntu
         config:
         # [Python version, tox env]
-        - ["3.8",   "lint"]
+        - ["3.9",   "lint"]
         - ["2.7",   "py27"]
         - ["3.5",   "py35"]
         - ["3.6",   "py36"]
         - ["3.7",   "py37"]
         - ["3.8",   "py38"]
         - ["3.9",   "py39"]
-        - ["3.8",   "docs"]
-        - ["3.8",   "coverage"]
+        - ["3.10",  "py310"]
+        - ["3.9",   "docs"]
+        - ["3.9",   "coverage"]
 
     runs-on: ${{ matrix.os }}-latest
     name: ${{ matrix.config[1] }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/zope-product
+*.dll
 *.egg-info/
 *.profraw
 *.pyc

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/zope-product
 [meta]
 template = "zope-product"
-commit-id = "9659f4d5d3dab75f0727e5e86349934c0bc776ae"
+commit-id = "3b712f305ca8207e971c5bf81f2bdb5872489f2f"
 
 [python]
 with-pypy = false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Products.CMFCore Changelog
 ==========================
 
-2.5.5 (unreleased)
+2.6.0 (unreleased)
 ------------------
 
 - Fix cookie test failure

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Products.CMFCore Changelog
 - Fix cookie test failure
   (`#120 <https://github.com/zopefoundation/Products.CMFCore/pull/120>`_).
 
+- Add support for Python 3.10.
 
 
 2.5.4 (2021-07-29)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+<!--
+Generated from:
+https://github.com/zopefoundation/meta/tree/master/config/zope-product
+--> 
+# Contributing to zopefoundation projects
+
+The projects under the zopefoundation GitHub organization are open source and
+welcome contributions in different forms:
+
+* bug reports
+* code improvements and bug fixes
+* documentation improvements
+* pull request reviews
+
+For any changes in the repository besides trivial typo fixes you are required
+to sign the contributor agreement. See
+https://www.zope.dev/developer/becoming-a-committer.html for details.
+
+Please visit our [Developer
+Guidelines](https://www.zope.dev/developer/guidelines.html) if you'd like to
+contribute code changes and our [guidelines for reporting
+bugs](https://www.zope.dev/developer/reporting-bugs.html) if you want to file a
+bug report.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/zope-product
+include *.md
 include *.rst
 include *.txt
 include buildout.cfg

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ README = _boundary.join([
 ])
 
 setup(name='Products.%s' % NAME,
-      version='2.5.5.dev0',
+      version='2.6.0.dev0',
       description='Zope Content Management Framework core components',
       long_description=README,
       classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(name='Products.%s' % NAME,
           'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
           'Programming Language :: Python :: 3.9',
+          'Programming Language :: Python :: 3.10',
           'Programming Language :: Python :: Implementation :: CPython',
           'Topic :: Software Development :: Libraries :: Application Frameworks',  # noqa
       ],

--- a/tox.ini
+++ b/tox.ini
@@ -10,15 +10,15 @@ envlist =
     py37
     py38
     py39
+    py310
     docs
     coverage
 
 [testenv]
 skip_install = true
-# We need to pin setuptools until we have zc.buildout 3.0.
 deps =
-    setuptools < 52
-    zc.buildout
+    zc.buildout >= 3.0.0rc3
+    wheel > 0.37
 commands_pre =
     py27,py35: {envbindir}/buildout -nc {toxinidir}/buildout4.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
     !py27-!py35: {envbindir}/buildout -nc {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
@@ -33,7 +33,7 @@ allowlist_externals =
     mkdir
 commands =
     isort --check-only --diff {toxinidir}/src {toxinidir}/setup.py
-    - flake8 --format=html {toxinidir}/src {toxinidir}/setup.py
+    - flake8 {toxinidir}/src {toxinidir}/setup.py
     flake8 {toxinidir}/src {toxinidir}/setup.py
     check-manifest
     check-python-versions
@@ -42,8 +42,6 @@ deps =
     check-python-versions
     flake8
     isort
-    # helper to generate HTML reports:
-    flake8-html
     # Useful flake8 plugins that are Python and Plone specific:
     flake8-coding
     flake8-debugger
@@ -60,8 +58,6 @@ commands =
 [testenv:docs]
 basepython = python3
 skip_install = false
-# Until repoze.sphinx.autointerface supports Sphinx 4.x we cannot use it:
-deps = Sphinx < 4
 extras =
     docs
 commands_pre =


### PR DESCRIPTION
Try out zc.buildout 3.0.0rc3. (Using https://github.com/zopefoundation/meta/pull/140)