### PR TITLE
URLTool: fix acquisition context for getPortalObject

### DIFF
--- a/src/Products/CMFCore/tests/test_ActionsTool.py
+++ b/src/Products/CMFCore/tests/test_ActionsTool.py
@@ -17,7 +17,9 @@ import unittest
 import warnings
 
 from AccessControl.SecurityManagement import newSecurityManager
+from Testing.makerequest import makerequest
 from zope.component import getSiteManager
+from zope.globalrequest import setRequest
 from zope.interface.verify import verifyClass
 from zope.testing.cleanup import cleanUp
 
@@ -42,7 +44,7 @@ class ActionsToolTests(unittest.TestCase):
         return ActionsTool
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return makerequest(self._getTargetClass()(*args, **kw))
 
     def test_interfaces(self):
         from ..interfaces import IActionProvider
@@ -121,13 +123,14 @@ class ActionsToolSecurityTests(SecurityTest):
         return ActionsTool
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return makerequest(self._getTargetClass()(*args, **kw))
 
     def setUp(self):
         from ..interfaces import IActionsTool
 
         SecurityTest.setUp(self)
         self.tool = self._makeOne()
+        setRequest(self.tool.REQUEST)
         self.tool.action_providers = ('portal_actions',)
         self.app._setObject('foo', URLTool())
         sm = getSiteManager()

--- a/src/Products/CMFCore/tests/test_URLTool.py
+++ b/src/Products/CMFCore/tests/test_URLTool.py
@@ -15,7 +15,9 @@
 
 import unittest
 
+from Testing.makerequest import makerequest
 from zope.component import getSiteManager
+from zope.globalrequest import setRequest
 from zope.interface.verify import verifyClass
 from zope.testing.cleanup import cleanUp
 
@@ -28,7 +30,8 @@ from .base.dummy import DummySite
 class URLToolTests(unittest.TestCase):
 
     def setUp(self):
-        self.site = DummySite(id='foo')
+        self.site = makerequest(DummySite(id='foo'))
+        setRequest(self.site.REQUEST)
         sm = getSiteManager()
         sm.registerUtility(self.site, ISiteRoot)
 
@@ -54,6 +57,10 @@ class URLToolTests(unittest.TestCase):
         self.assertEqual(url_tool(), 'http://www.foobar.com/bar/foo')
         self.assertEqual(url_tool.getPortalObject(), self.site)
         self.assertEqual(url_tool.getPortalPath(), '/bar/foo')
+
+    def test_getPortalObject_aq_context(self):
+        url_tool = self._makeOne()
+        self.assertEqual(url_tool.getPortalObject().REQUEST, self.site.REQUEST)
 
     def test_content_methods(self):
         url_tool = self._makeOne()


### PR DESCRIPTION
Use logic from a CMFCore.CMFPlone patch
https://github.com/plone/Products.CMFPlone/pull/2205

see https://github.com/plone/Products.CMFPlone/issues/2194