### PR TITLE
Make decodeFolderFilter and encodeFolderFilter non-public.

### DIFF
--- a/.github/workflows/tests-27.yml
+++ b/.github/workflows/tests-27.yml
@@ -29,10 +29,6 @@ jobs:
     name: ${{ matrix.config[1] }}
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.config[0] }}
     - name: Pip cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/tests-27.yml
+++ b/.github/workflows/tests-27.yml
@@ -20,18 +20,11 @@ jobs:
         - ["ubuntu", "ubuntu-20.04"]
         config:
         # [Python version, tox env]
-        - ["3.9",   "lint"]
-        - ["3.5",   "py35"]
-        - ["3.6",   "py36"]
-        - ["3.7",   "py37"]
-        - ["3.8",   "py38"]
-        - ["3.9",   "py39"]
-        - ["3.10",  "py310"]
-        - ["3.11",  "py311"]
-        - ["3.9",   "docs"]
-        - ["3.9",   "coverage"]
+        - ["2.7",   "py27"]
 
     runs-on: ${{ matrix.os[1] }}
+    container:
+      image: python:2.7.18-buster
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Products.CMFCore Changelog
 2.7.1 (unreleased)
 ------------------
 
+- Make ``decodeFolderFilter`` and ``encodeFolderFilter`` non-public.
+  This is the workaround from `CVE-2023-36814 <https://github.com/zopefoundation/Products.CMFCore/security/advisories/GHSA-4hpj-8rhv-9x87>`_.
+
 
 2.7.0 (2022-12-16)
 ------------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -27,8 +27,3 @@ eggs =
     Sphinx
 scripts =
     sphinx-build
-
-[versions:python36]
-Products.StandardCacheManagers = <5.0
-zc.recipe.testrunner = 2.2
-zope.testrunner = 5.6

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -29,4 +29,6 @@ scripts =
     sphinx-build
 
 [versions:python36]
+Products.StandardCacheManagers = <5.0
 zc.recipe.testrunner = 2.2
+zope.testrunner = 5.6

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -27,3 +27,6 @@ eggs =
     Sphinx
 scripts =
     sphinx-build
+
+[versions:python36]
+zc.recipe.testrunner = 2.2

--- a/buildout4.cfg
+++ b/buildout4.cfg
@@ -5,3 +5,8 @@ extends =
 
 [versions]
 Products.CMFCore =
+# Use whatever setuptools/pip versions are already available.
+# Otherwise you get a buildout restart, and then it can't find
+# the buildout file anymore.
+pip =
+setuptools =

--- a/buildout4.cfg
+++ b/buildout4.cfg
@@ -5,6 +5,8 @@ extends =
 
 [versions]
 Products.CMFCore =
+
+Products.StandardCacheManagers = <5.0
 # Use whatever setuptools/pip versions are already available.
 # Otherwise you get a buildout restart, and then it can't find
 # the buildout file anymore.

--- a/src/Products/CMFCore/PortalFolder.py
+++ b/src/Products/CMFCore/PortalFolder.py
@@ -233,11 +233,8 @@ class PortalFolderBase(DynamicType, OpaqueItemManager, Folder):
     #
     #   other methods
     #
-    @security.public
     def encodeFolderFilter(self, REQUEST):
-        """
-            Parse cookie string for using variables in dtml.
-        """
+        # Parse cookie string for using variables in dtml.
         filter = {}
         for key, value in REQUEST.items():
             if key[:10] == 'filter_by_':
@@ -246,11 +243,8 @@ class PortalFolderBase(DynamicType, OpaqueItemManager, Folder):
         encoded = ''.join(encoded.split('\n'))
         return encoded
 
-    @security.public
     def decodeFolderFilter(self, encoded):
-        """
-            Parse cookie string for using variables in dtml.
-        """
+        # Parse cookie string for using variables in dtml.
         filter = {}
         if encoded:
             filter.update(marshal.loads(base64_decode(encoded)))

--- a/src/Products/CMFCore/exportimport/tests/test_cachingpolicymgr.py
+++ b/src/Products/CMFCore/exportimport/tests/test_cachingpolicymgr.py
@@ -13,6 +13,7 @@
 """Caching policy manager xml adapter and setup handler unit tests.
 """
 
+import six
 import unittest
 
 from OFS.Folder import Folder
@@ -46,6 +47,19 @@ _CPM_BODY = b"""\
     no_transform="False"
     predicate="python:object.getPortalTypeName() == &#x27;Foo&#x27;"
     private="False" proxy_revalidate="False" public="False" vary=""/>
+</object>
+"""
+
+# On Python 2.7 the tests fail if we use '&#x27;'.
+_CPM_BODY_27 = b"""\
+<?xml version="1.0" encoding="utf-8"?>
+<object name="caching_policy_manager" meta_type="CMF Caching Policy Manager">
+ <caching-policy name="foo_policy" enable_304s="False" etag_func=""
+    last_modified="True" max_age_secs="600" mtime_func="object/modified"
+    must_revalidate="False" no_cache="False" no_store="False"
+    no_transform="False"
+    predicate="python:object.getPortalTypeName() == 'Foo'" private="False"
+    proxy_revalidate="False" public="False" vary=""/>
 </object>
 """
 
@@ -83,7 +97,10 @@ class CachingPolicyManagerXMLAdapterTests(BodyAdapterTestCase,
 
     def setUp(self):
         self._obj = CachingPolicyManager()
-        self._BODY = _CPM_BODY
+        if six.PY3:
+            self._BODY = _CPM_BODY
+        else:
+            self._BODY = _CPM_BODY_27
 
 
 class _CachingPolicyManagerSetup(BaseRegistryTests):

--- a/src/Products/CMFCore/exportimport/tests/test_cachingpolicymgr.py
+++ b/src/Products/CMFCore/exportimport/tests/test_cachingpolicymgr.py
@@ -13,8 +13,9 @@
 """Caching policy manager xml adapter and setup handler unit tests.
 """
 
-import six
 import unittest
+
+import six
 
 from OFS.Folder import Folder
 from zope.component import getSiteManager

--- a/src/Products/CMFCore/tests/test_ActionInformation.py
+++ b/src/Products/CMFCore/tests/test_ActionInformation.py
@@ -158,10 +158,20 @@ class ActionTests(unittest.TestCase):
         self.assertFalse(hasattr(a, 'available_expr_object'))
 
 
+class DummyResponse:
+
+    def getHeader(self, key):
+        return ''
+
+    def setHeader(self, key, value):
+        pass
+
+
 class DummyRequest:
 
     charset = 'UTF-8'
     URL = ''
+    RESPONSE = DummyResponse()
 
     def __init__(self):
         self._data = {}

--- a/src/Products/CMFCore/tests/test_ActionProviderBase.py
+++ b/src/Products/CMFCore/tests/test_ActionProviderBase.py
@@ -51,7 +51,7 @@ class DummyAction:
 
     def __eq__(self, other):
         return (
-            type(self) == type(other) and
+            type(self) is type(other) and
             self.__class__ == other.__class__ and
             self.value == other.value
         )

--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,8 @@ deps =
     zc.buildout >= 3.0.1
     wheel > 0.37
 commands_pre =
-    py27,py35: {envbindir}/buildout -nc {toxinidir}/buildout4.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
-    !py27-!py35: {envbindir}/buildout -nc {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+    py27,py35,py36: {envbindir}/buildout -nc {toxinidir}/buildout4.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+    !py27-!py35-!py36: {envbindir}/buildout -nc {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
 commands =
     {envdir}/bin/test {posargs:-cv}
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,10 +37,10 @@ commands =
     - flake8 {toxinidir}/src {toxinidir}/setup.py
     flake8 {toxinidir}/src {toxinidir}/setup.py
     check-manifest
-    check-python-versions
+#    check-python-versions
 deps =
     check-manifest
-    check-python-versions
+#    check-python-versions
     flake8
     isort
     # Useful flake8 plugins that are Python and Plone specific:


### PR DESCRIPTION
This is the workaround from [CVE-2023-36814](https://github.com/zopefoundation/Products.CMFCore/security/advisories/GHSA-4hpj-8rhv-9x87).  Would be good to have this available for Plone 5.2.

Plus one linting fix in the tests.