### PR TITLE
Use the new resources keyword of registerClass if available.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Products.CMFCore Changelog
 3.5 (unreleased)
 ----------------
 
+- Use the new ``resources`` keyword of ``registerClass`` if available.
+  This avoids a deprecation warning for using a non callable constructor in Zope higher than 5.9.
+  (`#1202 <https://github.com/zopefoundation/Zope/issues/1202>`_)
+
 
 3.4 (2024-04-12)
 ----------------
@@ -17,7 +21,7 @@ Products.CMFCore Changelog
 
 - Add support for Python 3.12.
 
-- ZMI: added limit of folderish objects for customizing and 
+- ZMI: added limit of folderish objects for customizing and
   handling SVG files as FSImage showing a preview.
   (`#130 <https://github.com/zopefoundation/Products.CMFCore/pull/130>`_)
 

--- a/src/Products/CMFCore/utils.py
+++ b/src/Products/CMFCore/utils.py
@@ -599,13 +599,20 @@ class ToolInit:
         # Add only one meta type to the folder add list.
         productObject = context._ProductContext__prod
         self.product_name = productObject.id
-        context.registerClass(
-            meta_type=self.meta_type,
-            # This is a little sneaky: we add self to the
-            # FactoryDispatcher under the name "toolinit".
-            # manage_addTool() can then grab it.
-            constructors=(manage_addToolForm, manage_addTool, self),
-            icon=self.icon)
+        # We add self to the FactoryDispatcher under the name 'toolinit'.
+        # manage_addContentType() can then grab it.
+        try:
+            context.registerClass(
+                meta_type=self.meta_type,
+                constructors=(manage_addToolForm, manage_addTool),
+                resources=(self, ),
+                icon=self.icon)
+        except TypeError:
+            # The 'resources' keyword was only introduced after Zope 5.9.
+            context.registerClass(
+                meta_type=self.meta_type,
+                constructors=(manage_addToolForm, manage_addTool, self),
+                icon=self.icon)
 
         if self.icon:
             icon = os_path.split(self.icon)[1]
@@ -680,15 +687,27 @@ class ContentInit:
 
     def initialize(self, context):
         # Add only one meta type to the folder add list.
-        context.registerClass(
-            meta_type=self.meta_type,
-            # This is a little sneaky: we add self to the
-            # FactoryDispatcher under the name "contentinit".
-            # manage_addContentType() can then grab it.
-            constructors=(manage_addContentForm, manage_addContent,
-                          self) + self.extra_constructors,
-            permission=self.permission,
-            visibility=self.visibility)
+        # We add self to the FactoryDispatcher under the name 'contentinit'.
+        # manage_addContentType() can then grab it.
+        try:
+            context.registerClass(
+                meta_type=self.meta_type,
+                constructors=(
+                    manage_addContentForm,
+                    manage_addContent,
+                    ) + self.extra_constructors,
+                resources=(self, ),
+                permission=self.permission,
+                visibility=self.visibility)
+        except TypeError:
+            # The 'resources' keyword was only introduced after Zope 5.9.
+            context.registerClass(
+                meta_type=self.meta_type,
+                constructors=(
+                    manage_addContentForm, manage_addContent, self,
+                    ) + self.extra_constructors,
+                permission=self.permission,
+                visibility=self.visibility)
 
         for ct in self.content_types:
             ct.__factory_meta_type__ = self.meta_type


### PR DESCRIPTION
This avoids a deprecation warning for using a non callable constructor in Zope higher than 5.9. See report in https://github.com/zopefoundation/Zope/issues/1202

This code works on Zope 5.9 (and likely earlier versions) and on current master after the merge of https://github.com/zopefoundation/Zope/pull/1205 which introduced the `resources` keyword.

`Products.CMFPlone` also has a `ToolInit` that is affected, but it inherits from the one in `CMFCore`, and it is fixed by this PR as well.