### PR TITLE
Avoid full object reindex on security reindex

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Products.CMFCore Changelog
 ----------------
 
 - Drop support for Python 3.7.
+- Fix reindexObjectSecurity to avoid a full reindex of affected objects
 
 
 3.5 (2024-03-23)

--- a/src/Products/CMFCore/CMFCatalogAware.py
+++ b/src/Products/CMFCore/CMFCatalogAware.py
@@ -125,7 +125,8 @@ class CatalogAware(Base):
                                'catalog', brain_path)
                 continue
             s = getattr(ob, '_p_changed', 0)
-            ob.reindexObject(idxs=self._cmf_security_indexes, update_metadata=0)
+            ob.reindexObject(idxs=self._cmf_security_indexes,
+                             update_metadata=0)
             if s is None:
                 ob._p_deactivate()
 

--- a/src/Products/CMFCore/CMFCatalogAware.py
+++ b/src/Products/CMFCore/CMFCatalogAware.py
@@ -125,7 +125,7 @@ class CatalogAware(Base):
                                'catalog', brain_path)
                 continue
             s = getattr(ob, '_p_changed', 0)
-            ob.reindexObject(idxs=self._cmf_security_indexes)
+            ob.reindexObject(idxs=self._cmf_security_indexes, update_metadata=0)
             if s is None:
                 ob._p_deactivate()
 

--- a/src/Products/CMFCore/tests/test_CMFCatalogAware.py
+++ b/src/Products/CMFCore/tests/test_CMFCatalogAware.py
@@ -194,9 +194,9 @@ class CMFCatalogAwareTests(unittest.TestCase, LogInterceptor):
         foo.reindexObjectSecurity()
         log = sorted(cat.log)
         self.assertEqual(log, [
-            'reindex /site/foo %s 1' % str(CMF_SECURITY_INDEXES),
-            'reindex /site/foo/bar %s 1' % str(CMF_SECURITY_INDEXES),
-            'reindex /site/foo/hop %s 1' % str(CMF_SECURITY_INDEXES),
+            'reindex /site/foo %s 0' % str(CMF_SECURITY_INDEXES),
+            'reindex /site/foo/bar %s 0' % str(CMF_SECURITY_INDEXES),
+            'reindex /site/foo/hop %s 0' % str(CMF_SECURITY_INDEXES),
             ])
         self.assertFalse(foo.notified)
         self.assertFalse(bar.notified)
@@ -227,7 +227,7 @@ class CMFCatalogAwareTests(unittest.TestCase, LogInterceptor):
         foo.reindexObjectSecurity()
         self.assertEqual(
             cat.log,
-            ['reindex /site/foo %s 1' % str(CMF_SECURITY_INDEXES)])
+            ['reindex /site/foo %s 0' % str(CMF_SECURITY_INDEXES)])
         self.assertFalse(foo.notified)
         self.assertFalse(missing.notified)
         self.assertEqual(len(self.logged), 1)  # logging because no raise


### PR DESCRIPTION
Add `update_metadata=0` parameter to `reindexObjectSecurity` to avoid a full reindex and instead just reindex `allowedRolesAndUsers`.

This fixes #142