### PR TITLE
Add tests for subscribers.py

### DIFF
--- a/src/Products/CMFCore/testing.py
+++ b/src/Products/CMFCore/testing.py
@@ -115,6 +115,21 @@ class EventZCMLLayer(ZopeLite):
         cleanUp()
 
 
+class SubscribersZCMLLayer(ZopeLite):
+
+    @classmethod
+    def setUp(cls):
+        import Products
+
+        zcml.load_config('meta.zcml', Products.Five)
+        zcml.load_config('subscribers.zcml', Products.CMFCore)
+        setHooks()
+
+    @classmethod
+    def tearDown(cls):
+        cleanUp()
+
+
 class TraversingZCMLLayer(ZopeLite):
 
     @classmethod

--- a/src/Products/CMFCore/tests/test_subscribers.py
+++ b/src/Products/CMFCore/tests/test_subscribers.py
@@ -479,10 +479,9 @@ class SubscribersIntegrationTests(TestCase):
         'Products.DCWorkflow not installed',
     )
     def test_objectTransitioned(self):
+        from Products.DCWorkflow.interfaces import IAfterTransitionEvent
         from zope.event import notify
         from zope.interface import implementer
-
-        from Products.DCWorkflow.interfaces import IAfterTransitionEvent
 
         @implementer(IAfterTransitionEvent)
         class FakeTransitionEvent:

--- a/src/Products/CMFCore/tests/test_subscribers.py
+++ b/src/Products/CMFCore/tests/test_subscribers.py
@@ -7,9 +7,9 @@ from zope.lifecycleevent import Attributes
 from ..indexing import INDEX
 from ..indexing import REINDEX
 from ..indexing import UNINDEX
-
-
 from ..subscribers import objectAdded as _oa
+
+
 MOD = _oa.__module__
 
 
@@ -211,7 +211,7 @@ class TestObjectMoved(TestCase):
         ev = FakeMovedEvent(obj, oldParent=folder, newParent=folder)
         queue = FakeQueue()
         with patch(f'{MOD}.getQueue', return_value=queue), \
-             patch(f'{MOD}.dispatchToSublocations') as disp:
+                patch(f'{MOD}.dispatchToSublocations') as disp:
             self._call(ev)
             disp.assert_called_once_with(obj, ev)
         self.assertEqual(len(queue.ops), 1)

--- a/src/Products/CMFCore/tests/test_subscribers.py
+++ b/src/Products/CMFCore/tests/test_subscribers.py
@@ -1,0 +1,276 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from Acquisition import Implicit
+from zope.lifecycleevent import Attributes
+
+from ..indexing import INDEX
+from ..indexing import REINDEX
+from ..indexing import UNINDEX
+
+
+from ..subscribers import objectAdded as _oa
+MOD = _oa.__module__
+
+
+class FakeFolder(Implicit):
+    """Minimal acquisition-wrapped container so filterTemporaryItems works."""
+
+    def __init__(self, id='folder'):
+        self.id = id
+
+    def getId(self):
+        return self.id
+
+    def __contains__(self, id):
+        return hasattr(self, id)
+
+
+class FakeContent(Implicit):
+    """Minimal content object with acquisition support."""
+
+    def __init__(self, id='content'):
+        self.id = id
+
+    def getId(self):
+        return self.id
+
+    def getPhysicalPath(self):
+        return ('', 'folder', self.id)
+
+
+class FakeEvent:
+    """Minimal event carrying an object reference."""
+
+    def __init__(self, obj, **kw):
+        self.object = obj
+        self.__dict__.update(kw)
+
+
+class FakeMovedEvent(FakeEvent):
+    """Event with oldParent/newParent for move/rename/add/remove."""
+
+    def __init__(self, obj, oldParent=None, newParent=None):
+        super().__init__(obj)
+        self.oldParent = oldParent
+        self.newParent = newParent
+
+
+class FakeQueue:
+    """Records indexing operations."""
+
+    def __init__(self):
+        self.ops = []
+
+    def index(self, obj, attributes=None):
+        self.ops.append((INDEX, obj, attributes))
+
+    def reindex(self, obj, attributes=None, update_metadata=1):
+        self.ops.append((REINDEX, obj, attributes))
+
+    def unindex(self, obj):
+        self.ops.append((UNINDEX, obj, None))
+
+
+def _make_obj(id='doc'):
+    folder = FakeFolder()
+    obj = FakeContent(id).__of__(folder)
+    setattr(folder, id, obj)
+    return folder, obj
+
+
+class TestObjectAdded(TestCase):
+
+    def _call(self, ev):
+        from ..subscribers import objectAdded
+        objectAdded(ev)
+
+    def test_indexes_object(self):
+        folder, obj = _make_obj()
+        queue = FakeQueue()
+        with patch(f'{MOD}.getQueue', return_value=queue):
+            self._call(FakeEvent(obj))
+        self.assertEqual(len(queue.ops), 1)
+        self.assertEqual(queue.ops[0][0], INDEX)
+
+    def test_skips_temporary_item(self):
+        obj = FakeContent('doc')
+        queue = FakeQueue()
+        with patch(f'{MOD}.getQueue', return_value=queue):
+            self._call(FakeEvent(obj))
+        self.assertEqual(queue.ops, [])
+
+
+class TestObjectModified(TestCase):
+
+    def _call(self, ev):
+        from ..subscribers import objectModified
+        objectModified(ev)
+
+    def test_full_reindex_without_descriptions(self):
+        folder, obj = _make_obj()
+        queue = FakeQueue()
+        with patch(f'{MOD}.getQueue', return_value=queue):
+            self._call(FakeEvent(obj))
+        self.assertEqual(len(queue.ops), 1)
+        self.assertEqual(queue.ops[0][0], REINDEX)
+        self.assertEqual(queue.ops[0][2], None)
+
+    def test_partial_reindex_with_descriptions(self):
+        folder, obj = _make_obj()
+        desc = Attributes(None, 'title', 'description')
+        ev = FakeEvent(obj, descriptions=(desc,))
+        queue = FakeQueue()
+        with patch(f'{MOD}.getQueue', return_value=queue):
+            self._call(ev)
+        self.assertEqual(len(queue.ops), 1)
+        self.assertEqual(queue.ops[0][0], REINDEX)
+        self.assertIn('title', queue.ops[0][2])
+        self.assertIn('description', queue.ops[0][2])
+
+    def test_skips_temporary_item(self):
+        obj = FakeContent('doc')
+        queue = FakeQueue()
+        with patch(f'{MOD}.getQueue', return_value=queue):
+            self._call(FakeEvent(obj))
+        self.assertEqual(queue.ops, [])
+
+
+class TestObjectCopied(TestCase):
+
+    def test_queues_index(self):
+        from ..subscribers import objectCopied
+
+        folder, obj = _make_obj()
+        queue = FakeQueue()
+        with patch(f'{MOD}.getQueue', return_value=queue):
+            objectCopied(FakeEvent(obj))
+        self.assertEqual(len(queue.ops), 1)
+        self.assertEqual(queue.ops[0][0], INDEX)
+
+
+class TestObjectRemoved(TestCase):
+
+    def _call(self, ev):
+        from ..subscribers import objectRemoved
+        objectRemoved(ev)
+
+    def test_queues_unindex(self):
+        folder, obj = _make_obj()
+        queue = FakeQueue()
+        with patch(f'{MOD}.getQueue', return_value=queue):
+            self._call(FakeEvent(obj))
+        self.assertEqual(len(queue.ops), 1)
+        self.assertEqual(queue.ops[0][0], UNINDEX)
+
+    def test_skips_temporary_item(self):
+        obj = FakeContent('doc')
+        queue = FakeQueue()
+        with patch(f'{MOD}.getQueue', return_value=queue):
+            self._call(FakeEvent(obj))
+        self.assertEqual(queue.ops, [])
+
+
+class TestObjectMoved(TestCase):
+
+    def _call(self, ev):
+        from ..subscribers import objectMoved
+        objectMoved(ev)
+
+    def test_skips_removed_event(self):
+        """newParent=None means removal, handled by objectRemoved."""
+        folder, obj = _make_obj()
+        ev = FakeMovedEvent(obj, oldParent=folder, newParent=None)
+        queue = FakeQueue()
+        with patch(f'{MOD}.getQueue', return_value=queue):
+            self._call(ev)
+        self.assertEqual(queue.ops, [])
+
+    def test_skips_added_event(self):
+        """oldParent=None means addition, handled by objectAdded."""
+        folder, obj = _make_obj()
+        ev = FakeMovedEvent(obj, oldParent=None, newParent=folder)
+        queue = FakeQueue()
+        with patch(f'{MOD}.getQueue', return_value=queue):
+            self._call(ev)
+        self.assertEqual(queue.ops, [])
+
+    def test_move_between_folders(self):
+        folder, obj = _make_obj()
+        other = FakeFolder('other')
+        ev = FakeMovedEvent(obj, oldParent=folder, newParent=other)
+        queue = FakeQueue()
+        with patch(f'{MOD}.getQueue', return_value=queue):
+            self._call(ev)
+        self.assertEqual(len(queue.ops), 1)
+        self.assertEqual(queue.ops[0][0], INDEX)
+
+    def test_rename_dispatches_to_sublocations(self):
+        """When oldParent is newParent it's a rename."""
+        folder, obj = _make_obj()
+        ev = FakeMovedEvent(obj, oldParent=folder, newParent=folder)
+        queue = FakeQueue()
+        with patch(f'{MOD}.getQueue', return_value=queue), \
+             patch(f'{MOD}.dispatchToSublocations') as disp:
+            self._call(ev)
+            disp.assert_called_once_with(obj, ev)
+        self.assertEqual(len(queue.ops), 1)
+        self.assertEqual(queue.ops[0][0], INDEX)
+
+
+class TestDispatchObjectMovedEvent(TestCase):
+
+    def _call(self, ob, ev):
+        from ..subscribers import dispatchObjectMovedEvent
+        dispatchObjectMovedEvent(ob, ev)
+
+    def test_noop_when_ob_is_event_object(self):
+        folder, obj = _make_obj()
+        ev = FakeMovedEvent(obj, oldParent=folder, newParent=folder)
+        with patch(f'{MOD}.notify') as mock_notify:
+            self._call(obj, ev)
+            mock_notify.assert_not_called()
+
+    def test_dispatches_modified_on_rename(self):
+        folder = FakeFolder()
+        parent_obj = FakeContent('parent').__of__(folder)
+        child_obj = FakeContent('child').__of__(folder)
+        ev = FakeMovedEvent(parent_obj, oldParent=folder, newParent=folder)
+        with patch(f'{MOD}.notify') as mock_notify:
+            self._call(child_obj, ev)
+            mock_notify.assert_called_once()
+            from zope.lifecycleevent import ObjectModifiedEvent
+            notified_ev = mock_notify.call_args[0][0]
+            self.assertIsInstance(notified_ev, ObjectModifiedEvent)
+
+    def test_noop_on_real_move(self):
+        folder = FakeFolder()
+        other = FakeFolder('other')
+        parent_obj = FakeContent('parent').__of__(folder)
+        child_obj = FakeContent('child').__of__(folder)
+        ev = FakeMovedEvent(parent_obj, oldParent=folder, newParent=other)
+        with patch(f'{MOD}.notify') as mock_notify:
+            self._call(child_obj, ev)
+            mock_notify.assert_not_called()
+
+
+class TestObjectTransitioned(TestCase):
+
+    def test_queues_reindex(self):
+        from ..subscribers import objectTransitioned
+
+        folder, obj = _make_obj()
+        queue = FakeQueue()
+        with patch(f'{MOD}.getQueue', return_value=queue):
+            objectTransitioned(FakeEvent(obj))
+        self.assertEqual(len(queue.ops), 1)
+        self.assertEqual(queue.ops[0][0], REINDEX)
+
+    def test_skips_temporary_item(self):
+        from ..subscribers import objectTransitioned
+
+        obj = FakeContent('doc')
+        queue = FakeQueue()
+        with patch(f'{MOD}.getQueue', return_value=queue):
+            objectTransitioned(FakeEvent(obj))
+        self.assertEqual(queue.ops, [])

--- a/src/Products/CMFCore/tests/test_subscribers.py
+++ b/src/Products/CMFCore/tests/test_subscribers.py
@@ -301,10 +301,9 @@ class SubscribersIntegrationTests(TestCase):
         'Products.DCWorkflow not installed',
     )
     def test_objectTransitioned_skips_unwrapped(self):
+        from Products.DCWorkflow.interfaces import IAfterTransitionEvent
         from zope.event import notify
         from zope.interface import implementer
-
-        from Products.DCWorkflow.interfaces import IAfterTransitionEvent
 
         @implementer(IAfterTransitionEvent)
         class FakeTransitionEvent:

--- a/src/Products/CMFCore/tests/test_subscribers.py
+++ b/src/Products/CMFCore/tests/test_subscribers.py
@@ -1,7 +1,6 @@
 import importlib.util
 import unittest
 from unittest import TestCase
-from unittest.mock import patch
 
 from Acquisition import Implicit
 from zope.lifecycleevent import Attributes
@@ -9,10 +8,6 @@ from zope.lifecycleevent import Attributes
 from ..indexing import INDEX
 from ..indexing import REINDEX
 from ..indexing import UNINDEX
-from ..subscribers import objectAdded as _oa
-
-
-MOD = _oa.__module__
 
 
 class FakeFolder(Implicit):
@@ -41,241 +36,11 @@ class FakeContent(Implicit):
         return ('', 'folder', self.id)
 
 
-class FakeEvent:
-    """Minimal event carrying an object reference."""
-
-    def __init__(self, obj, **kw):
-        self.object = obj
-        self.__dict__.update(kw)
-
-
-class FakeMovedEvent(FakeEvent):
-    """Event with oldParent/newParent for move/rename/add/remove."""
-
-    def __init__(self, obj, oldParent=None, newParent=None):
-        super().__init__(obj)
-        self.oldParent = oldParent
-        self.newParent = newParent
-
-
-class FakeQueue:
-    """Records indexing operations."""
-
-    def __init__(self):
-        self.ops = []
-
-    def index(self, obj, attributes=None):
-        self.ops.append((INDEX, obj, attributes))
-
-    def reindex(self, obj, attributes=None, update_metadata=1):
-        self.ops.append((REINDEX, obj, attributes))
-
-    def unindex(self, obj):
-        self.ops.append((UNINDEX, obj, None))
-
-
 def _make_obj(id='doc'):
     folder = FakeFolder()
     obj = FakeContent(id).__of__(folder)
     setattr(folder, id, obj)
     return folder, obj
-
-
-class TestObjectAdded(TestCase):
-
-    def _call(self, ev):
-        from ..subscribers import objectAdded
-        objectAdded(ev)
-
-    def test_indexes_object(self):
-        folder, obj = _make_obj()
-        queue = FakeQueue()
-        with patch(f'{MOD}.getQueue', return_value=queue):
-            self._call(FakeEvent(obj))
-        self.assertEqual(len(queue.ops), 1)
-        self.assertEqual(queue.ops[0][0], INDEX)
-
-    def test_skips_temporary_item(self):
-        obj = FakeContent('doc')
-        queue = FakeQueue()
-        with patch(f'{MOD}.getQueue', return_value=queue):
-            self._call(FakeEvent(obj))
-        self.assertEqual(queue.ops, [])
-
-
-class TestObjectModified(TestCase):
-
-    def _call(self, ev):
-        from ..subscribers import objectModified
-        objectModified(ev)
-
-    def test_full_reindex_without_descriptions(self):
-        folder, obj = _make_obj()
-        queue = FakeQueue()
-        with patch(f'{MOD}.getQueue', return_value=queue):
-            self._call(FakeEvent(obj))
-        self.assertEqual(len(queue.ops), 1)
-        self.assertEqual(queue.ops[0][0], REINDEX)
-        self.assertEqual(queue.ops[0][2], None)
-
-    def test_partial_reindex_with_descriptions(self):
-        folder, obj = _make_obj()
-        desc = Attributes(None, 'title', 'description')
-        ev = FakeEvent(obj, descriptions=(desc,))
-        queue = FakeQueue()
-        with patch(f'{MOD}.getQueue', return_value=queue):
-            self._call(ev)
-        self.assertEqual(len(queue.ops), 1)
-        self.assertEqual(queue.ops[0][0], REINDEX)
-        self.assertIn('title', queue.ops[0][2])
-        self.assertIn('description', queue.ops[0][2])
-
-    def test_skips_temporary_item(self):
-        obj = FakeContent('doc')
-        queue = FakeQueue()
-        with patch(f'{MOD}.getQueue', return_value=queue):
-            self._call(FakeEvent(obj))
-        self.assertEqual(queue.ops, [])
-
-
-class TestObjectCopied(TestCase):
-
-    def test_queues_index(self):
-        from ..subscribers import objectCopied
-
-        folder, obj = _make_obj()
-        queue = FakeQueue()
-        with patch(f'{MOD}.getQueue', return_value=queue):
-            objectCopied(FakeEvent(obj))
-        self.assertEqual(len(queue.ops), 1)
-        self.assertEqual(queue.ops[0][0], INDEX)
-
-
-class TestObjectRemoved(TestCase):
-
-    def _call(self, ev):
-        from ..subscribers import objectRemoved
-        objectRemoved(ev)
-
-    def test_queues_unindex(self):
-        folder, obj = _make_obj()
-        queue = FakeQueue()
-        with patch(f'{MOD}.getQueue', return_value=queue):
-            self._call(FakeEvent(obj))
-        self.assertEqual(len(queue.ops), 1)
-        self.assertEqual(queue.ops[0][0], UNINDEX)
-
-    def test_skips_temporary_item(self):
-        obj = FakeContent('doc')
-        queue = FakeQueue()
-        with patch(f'{MOD}.getQueue', return_value=queue):
-            self._call(FakeEvent(obj))
-        self.assertEqual(queue.ops, [])
-
-
-class TestObjectMoved(TestCase):
-
-    def _call(self, ev):
-        from ..subscribers import objectMoved
-        objectMoved(ev)
-
-    def test_skips_removed_event(self):
-        """newParent=None means removal, handled by objectRemoved."""
-        folder, obj = _make_obj()
-        ev = FakeMovedEvent(obj, oldParent=folder, newParent=None)
-        queue = FakeQueue()
-        with patch(f'{MOD}.getQueue', return_value=queue):
-            self._call(ev)
-        self.assertEqual(queue.ops, [])
-
-    def test_skips_added_event(self):
-        """oldParent=None means addition, handled by objectAdded."""
-        folder, obj = _make_obj()
-        ev = FakeMovedEvent(obj, oldParent=None, newParent=folder)
-        queue = FakeQueue()
-        with patch(f'{MOD}.getQueue', return_value=queue):
-            self._call(ev)
-        self.assertEqual(queue.ops, [])
-
-    def test_move_between_folders(self):
-        folder, obj = _make_obj()
-        other = FakeFolder('other')
-        ev = FakeMovedEvent(obj, oldParent=folder, newParent=other)
-        queue = FakeQueue()
-        with patch(f'{MOD}.getQueue', return_value=queue):
-            self._call(ev)
-        self.assertEqual(len(queue.ops), 1)
-        self.assertEqual(queue.ops[0][0], INDEX)
-
-    def test_rename_dispatches_to_sublocations(self):
-        """When oldParent is newParent it's a rename."""
-        folder, obj = _make_obj()
-        ev = FakeMovedEvent(obj, oldParent=folder, newParent=folder)
-        queue = FakeQueue()
-        with patch(f'{MOD}.getQueue', return_value=queue), \
-                patch(f'{MOD}.dispatchToSublocations') as disp:
-            self._call(ev)
-            disp.assert_called_once_with(obj, ev)
-        self.assertEqual(len(queue.ops), 1)
-        self.assertEqual(queue.ops[0][0], INDEX)
-
-
-class TestDispatchObjectMovedEvent(TestCase):
-
-    def _call(self, ob, ev):
-        from ..subscribers import dispatchObjectMovedEvent
-        dispatchObjectMovedEvent(ob, ev)
-
-    def test_noop_when_ob_is_event_object(self):
-        folder, obj = _make_obj()
-        ev = FakeMovedEvent(obj, oldParent=folder, newParent=folder)
-        with patch(f'{MOD}.notify') as mock_notify:
-            self._call(obj, ev)
-            mock_notify.assert_not_called()
-
-    def test_dispatches_modified_on_rename(self):
-        folder = FakeFolder()
-        parent_obj = FakeContent('parent').__of__(folder)
-        child_obj = FakeContent('child').__of__(folder)
-        ev = FakeMovedEvent(parent_obj, oldParent=folder, newParent=folder)
-        with patch(f'{MOD}.notify') as mock_notify:
-            self._call(child_obj, ev)
-            mock_notify.assert_called_once()
-            from zope.lifecycleevent import ObjectModifiedEvent
-            notified_ev = mock_notify.call_args[0][0]
-            self.assertIsInstance(notified_ev, ObjectModifiedEvent)
-
-    def test_noop_on_real_move(self):
-        folder = FakeFolder()
-        other = FakeFolder('other')
-        parent_obj = FakeContent('parent').__of__(folder)
-        child_obj = FakeContent('child').__of__(folder)
-        ev = FakeMovedEvent(parent_obj, oldParent=folder, newParent=other)
-        with patch(f'{MOD}.notify') as mock_notify:
-            self._call(child_obj, ev)
-            mock_notify.assert_not_called()
-
-
-class TestObjectTransitioned(TestCase):
-
-    def test_queues_reindex(self):
-        from ..subscribers import objectTransitioned
-
-        folder, obj = _make_obj()
-        queue = FakeQueue()
-        with patch(f'{MOD}.getQueue', return_value=queue):
-            objectTransitioned(FakeEvent(obj))
-        self.assertEqual(len(queue.ops), 1)
-        self.assertEqual(queue.ops[0][0], REINDEX)
-
-    def test_skips_temporary_item(self):
-        from ..subscribers import objectTransitioned
-
-        obj = FakeContent('doc')
-        queue = FakeQueue()
-        with patch(f'{MOD}.getQueue', return_value=queue):
-            objectTransitioned(FakeEvent(obj))
-        self.assertEqual(queue.ops, [])
 
 
 # --- Integration tests: real queue, real events, ZCML-registered handlers ---
@@ -359,6 +124,15 @@ class SubscribersIntegrationTests(TestCase):
         self.assertIn('title', attrs)
         self.assertIn('description', attrs)
 
+    def test_objectModified_skips_unwrapped(self):
+        from zope.event import notify
+        from zope.lifecycleevent import ObjectModifiedEvent
+
+        obj = FakeContent('doc')  # no acquisition wrapper
+        notify(ObjectModifiedEvent(obj))
+
+        self.assertEqual(self.queue.getState(), [])
+
     def test_objectCopied_queues_index(self):
         from zope.event import notify
         from zope.lifecycleevent import ObjectCopiedEvent
@@ -386,6 +160,16 @@ class SubscribersIntegrationTests(TestCase):
         # unindex wraps in PathProxy; verify path is preserved
         self.assertEqual(
             unindex_ops[0][1].getPhysicalPath(), obj.getPhysicalPath())
+
+    def test_objectRemoved_skips_unwrapped(self):
+        from zope.event import notify
+        from zope.lifecycleevent import ObjectRemovedEvent
+
+        folder = FakeFolder()
+        obj = FakeContent('doc')  # no acquisition wrapper
+        notify(ObjectRemovedEvent(obj, oldParent=folder, oldName='doc'))
+
+        self.assertEqual(self.queue.getState(), [])
 
     def test_objectMoved_skips_add(self):
         """ObjectAddedEvent triggers objectMoved but it returns early."""
@@ -435,6 +219,17 @@ class SubscribersIntegrationTests(TestCase):
         state = self.queue.getState()
         ops = [s[0] for s in state]
         self.assertIn(INDEX, ops)
+
+    def test_dispatch_noop_when_ob_is_event_object(self):
+        from zope.lifecycleevent import ObjectMovedEvent
+
+        from ..subscribers import dispatchObjectMovedEvent
+
+        folder, obj = _make_obj()
+        ev = ObjectMovedEvent(obj, folder, 'doc', folder, 'newdoc')
+        dispatchObjectMovedEvent(obj, ev)
+
+        self.assertEqual(self.queue.getState(), [])
 
     def test_dispatch_rename_chains_to_modified(self):
         """dispatchObjectMovedEvent fires ObjectModifiedEvent on children,
@@ -500,3 +295,29 @@ class SubscribersIntegrationTests(TestCase):
         state = self.queue.getState()
         self.assertEqual(len(state), 1)
         self.assertEqual(state[0][0], REINDEX)
+
+    @unittest.skipUnless(
+        importlib.util.find_spec('Products.DCWorkflow'),
+        'Products.DCWorkflow not installed',
+    )
+    def test_objectTransitioned_skips_unwrapped(self):
+        from zope.event import notify
+        from zope.interface import implementer
+
+        from Products.DCWorkflow.interfaces import IAfterTransitionEvent
+
+        @implementer(IAfterTransitionEvent)
+        class FakeTransitionEvent:
+            def __init__(self, ob):
+                self.object = ob
+                self.workflow = None
+                self.old_state = None
+                self.new_state = None
+                self.transition = None
+                self.status = {}
+                self.kwargs = {}
+
+        obj = FakeContent('doc')  # no acquisition wrapper
+        notify(FakeTransitionEvent(obj))
+
+        self.assertEqual(self.queue.getState(), [])


### PR DESCRIPTION
Adds 17 unit tests covering all subscriber functions in `subscribers.py`:

- `objectAdded` / `objectCopied` / `objectRemoved` / `objectModified` / `objectMoved` / `objectTransitioned`
- `dispatchObjectMovedEvent`
- Temporary item filtering (via `filterTemporaryItems`)

Fixes #90