### PR TITLE
Skip reindexObjectSecurity in deleteLocalRoles when no roles changed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Products.CMFCore Changelog
 3.9 (unreleased)
 ----------------
 
+- Optimize ``deleteLocalRoles`` to skip ``reindexObjectSecurity`` when no
+  local roles were actually deleted. This avoids a full security reindex
+  when deleting a user who has no local roles assigned.
+  (`#140 <https://github.com/zopefoundation/Products.CMFCore/issues/140>`_)
+
 - Fix ``reindexObjectSecurity`` to not trigger ``processQueue()`` mid-request.
   Uses ``_unrestrictedSearchResults`` that bypasses the indexing queue flush,
   consistent with existing ``_indexObject``/``_reindexObject``/

--- a/src/Products/CMFCore/MembershipTool.py
+++ b/src/Products/CMFCore/MembershipTool.py
@@ -458,19 +458,25 @@ class MembershipTool(UniqueObject, Folder):
                          REQUEST=None):
         """ Delete local roles of specified members.
         """
+        changed = False
         if _checkPermission(ChangeLocalRoles, obj):
             for member_id in member_ids:
                 if obj.get_local_roles_for_userid(userid=member_id):
                     obj.manage_delLocalRoles(userids=member_ids)
+                    changed = True
                     break
 
         if recursive and hasattr(aq_base(obj), 'contentValues'):
             for subobj in obj.contentValues():
-                self.deleteLocalRoles(subobj, member_ids, 0, 1)
+                if self.deleteLocalRoles(subobj, member_ids, 0, 1):
+                    changed = True
 
-        if reindex and hasattr(aq_base(obj), 'reindexObjectSecurity'):
+        if reindex and changed \
+                and hasattr(aq_base(obj), 'reindexObjectSecurity'):
             # reindexObjectSecurity is always recursive
             obj.reindexObjectSecurity()
+
+        return changed
 
     @security.private
     def addMember(self, id, password, roles, domains, properties=None):

--- a/src/Products/CMFCore/interfaces/_tools.py
+++ b/src/Products/CMFCore/interfaces/_tools.py
@@ -841,13 +841,13 @@ class IMembershipTool(Interface):
 
         o 'member_ids' is a sequence of user IDs from which to remove the role.
 
-        o If 'reindex' is True, then reindex the security-related attributes
-          of the object and all subobjects.
+        o If 'reindex' is True, reindex the security-related attributes
+          of the object and all subobjects, but only if local roles were
+          actually deleted.
 
-        o if 'recursive' is True, recurse over all subobjects of 'object'.
+        o If 'recursive' is True, recurse over all subobjects of 'object'.
 
-        o Raise Unauthorized if the currently-authenticated member cannot
-          assign 'member_role' on 'obj'.
+        o Return True if any local roles were actually deleted, else False.
 
         Permission:  Public
         """


### PR DESCRIPTION
When deleting a user, `deleteLocalRoles` traverses the entire site tree
and then calls `reindexObjectSecurity()` on the portal root — even if
the user has zero local roles anywhere. This reindexes
`allowedRolesAndUsers` for every cataloged object, which is very
expensive on large sites.

This tracks whether `manage_delLocalRoles` was actually called during
traversal and skips `reindexObjectSecurity` when nothing changed.
The method now returns `True`/`False` indicating whether any roles
were deleted (backward-compatible, all callers ignore the return value).

Fixes #140