### PR TITLE
Fix: ensure site manager is active during queue processing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Products.CMFCore Changelog
 3.10 (unreleased)
 -----------------
 
+- Fix ``PortalCatalogProcessor`` to ensure a local site manager is active
+  before processing catalog operations. When the indexing queue is processed
+  outside a request (e.g. in a ``before_commit`` hook), ``getSite()`` may
+  return ``None``, causing indexer adapters to not be found.
+  (`#160 <https://github.com/zopefoundation/Products.CMFCore/issues/160>`_)
 
 3.9 (2026-03-23)
 ----------------

--- a/src/Products/CMFCore/indexing.py
+++ b/src/Products/CMFCore/indexing.py
@@ -38,14 +38,42 @@ class PortalCatalogProcessor:
     """An index queue processor for the standard portal catalog via
        the `CatalogMultiplex` and `CMFCatalogAware` mixin classes """
 
+    @staticmethod
+    def _ensure_site(obj):
+        """Ensure a local site manager is active.
+
+        When the indexing queue is processed outside a request (e.g. in a
+        ``before_commit`` hook), ``getSite()`` may return ``None``.
+        Component lookups — especially indexer adapters used by
+        ``IndexableObjectWrapper`` — then fall back to the global site
+        manager and fail to find locally registered adapters.
+
+        Walk the object's acquisition chain to find a site and activate
+        it so that local component registrations are available during
+        catalog operations.
+        """
+        from zope.component.hooks import getSite
+        from zope.component.hooks import setSite
+        if getSite() is not None:
+            return
+        from zope.component.interfaces import ISite
+        current = obj
+        while current is not None:
+            if ISite.providedBy(current):
+                setSite(current)
+                return
+            current = aq_parent(current)
+
     def index(self, obj, attributes=None):
         catalog = getToolByName(obj, 'portal_catalog', None)
         if catalog is not None:
+            self._ensure_site(obj)
             catalog._indexObject(obj)
 
     def reindex(self, obj, attributes=None, update_metadata=1):
         catalog = getToolByName(obj, 'portal_catalog', None)
         if catalog is not None:
+            self._ensure_site(obj)
             catalog._reindexObject(
                 obj,
                 idxs=attributes,
@@ -54,6 +82,7 @@ class PortalCatalogProcessor:
     def unindex(self, obj):
         catalog = getToolByName(obj, 'portal_catalog', None)
         if catalog is not None:
+            self._ensure_site(obj)
             catalog._unindexObject(obj)
 
     def begin(self):

--- a/src/Products/CMFCore/indexing.py
+++ b/src/Products/CMFCore/indexing.py
@@ -9,6 +9,9 @@ from Acquisition import aq_parent
 from transaction import get as getTransaction
 from transaction.interfaces import ISavepointDataManager
 from zope.component import getSiteManager
+from zope.component.hooks import getSite
+from zope.component.hooks import setSite
+from zope.component.interfaces import ISite
 from zope.interface import implementer
 from zope.proxy import ProxyBase
 from zope.proxy import non_overridable
@@ -52,11 +55,8 @@ class PortalCatalogProcessor:
         it so that local component registrations are available during
         catalog operations.
         """
-        from zope.component.hooks import getSite
-        from zope.component.hooks import setSite
         if getSite() is not None:
             return
-        from zope.component.interfaces import ISite
         current = obj
         while current is not None:
             if ISite.providedBy(current):


### PR DESCRIPTION
## Summary

- When the indexing queue is processed outside a request (e.g. `before_commit` hook), `getSite()` returns `None`
- `IndexableObjectWrapper` falls back to global site manager → local indexer adapters not found → attributes like `exclude_from_nav` silently not indexed
- Previously masked because `processQueue()` was called mid-request (via `reindexObjectSecurity` → `unrestrictedSearchResults`) when the site was always set
- Since #155 bypasses `processQueue` in `reindexObjectSecurity`, more operations are deferred to `before_commit` where the site may not be set

Fix: `PortalCatalogProcessor._ensure_site()` walks the object's acquisition chain to find and activate a site before each catalog operation.

Refs: plone/buildout.coredev#1080

## Test plan

- [ ] CMFCore tests pass
- [ ] Plone 6.2 coredev tests that failed with CMFCore 3.9 now pass (navigation, plone.api needs separate test fix)

transparency: assisted by Claude Code Opus 4.6