### PR TITLE
Optimize object moves by reindexing only context-aware indexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .eggs/
 .installed.cfg
 .mr.developer.cfg
+.python-version
 .tox/
 .vscode/
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 .eggs/
 .installed.cfg
 .mr.developer.cfg
-.python-version
 .tox/
 .vscode/
 __pycache__/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,17 @@ Products.CMFCore Changelog
   A new ``moveObject(object, old_path, idxs)`` method is added to
   ``CatalogTool`` and ``ICatalogTool`` to implement the path remap.
 
+  The pre-move path is now stored via ``Transaction.set_data`` /
+  ``Transaction.data`` (keyed by the object's ZODB ``_p_oid``) instead of a
+  volatile ``_v_cmf_old_path`` attribute on each object.  Volatile attributes
+  are discarded whenever the ZODB object cache evicts an object
+  (ghostification); for subtrees larger than the configured cache size this
+  caused the optimisation to silently fall back to a full reindex for all
+  objects ghostified between the ``IObjectWillBeMovedEvent`` and
+  ``IObjectMovedEvent`` phases.  Transaction-attached data lives outside the
+  ZODB object graph, is never affected by cache pressure, and is discarded
+  automatically on commit or abort.
+
 - Add ``IContextAwareIndexProvider``, a named-utility interface that
   contributes catalog index names which must be reindexed on object moves
   (path-sensitive, security-sensitive, etc.).  Register a named utility

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,20 @@ Products.CMFCore Changelog
 3.10 (unreleased)
 -----------------
 
+- Optimize object moves by reindexing only context-aware indexes instead of
+  a full unindex + reindex.  The catalog RID is preserved across the move,
+  avoiding stale references and unnecessary work.
+  A new ``moveObject(object, old_path, idxs)`` method is added to
+  ``CatalogTool`` and ``ICatalogTool`` to implement the path remap.
+
+- Add ``IContextAwareIndexProvider``, a named-utility interface that
+  contributes catalog index names which must be reindexed on object moves
+  (path-sensitive, security-sensitive, etc.).  Register a named utility
+  providing this interface to extend the default set (``path``, ``getId``,
+  ``id``, ``allowedRolesAndUsers``).  The helper
+  ``CMFCatalogAware.get_context_aware_indexes()`` aggregates all registered
+  providers.
+
 
 3.9 (2026-03-23)
 ----------------

--- a/docs/api/tools.rst
+++ b/docs/api/tools.rst
@@ -58,6 +58,17 @@ and search content.  See also the interfaces for :ref:`searchable_content`.
 .. autointerface::  Products.CMFCore.interfaces.ICatalogTool
    :members:
 
+When an object is moved within the content tree, the catalog only reindexes
+the *context-aware* indexes (those whose value depends on the object's
+location, such as ``path``, ``getId``, ``id`` and ``allowedRolesAndUsers``)
+rather than performing a full unindex and reindex.  Packages that implement
+their own location- or security-sensitive index can extend the set of
+reindexed indexes by registering a named utility providing
+``IContextAwareIndexProvider``.
+
+.. autointerface::  Products.CMFCore.interfaces.IContextAwareIndexProvider
+   :members:
+
 
 
 .. _content_type_registry:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,1 +1,2 @@
+
 .. include:: ../CHANGES.rst

--- a/src/Products/CMFCore/CMFCatalogAware.py
+++ b/src/Products/CMFCore/CMFCatalogAware.py
@@ -14,6 +14,7 @@
 """
 
 import logging
+import transaction
 
 from AccessControl.class_init import InitializeClass
 from AccessControl.SecurityInfo import ClassSecurityInfo
@@ -310,6 +311,47 @@ class _BuiltinSecurityIndexProvider:
         return ('allowedRolesAndUsers',)
 
 
+class _MovePathsRegistryKey:
+    """Singleton used as key for ``transaction.set_data`` / ``transaction.data``.
+
+    The ``transaction`` package stores arbitrary per-transaction data via
+    ``Transaction.set_data(ob, value)`` / ``Transaction.data(ob)``, keyed by
+    the identity (``id``) of *ob*.  Using a module-level singleton that is
+    never garbage-collected gives a stable, collision-free key.
+    """
+
+
+#: Singleton key for the pending-move registry stored on the transaction.
+_MOVE_PATHS_KEY = _MovePathsRegistryKey()
+
+
+def _pending_move_paths():
+    """Return the transaction-local dict ``{oid: old_path}`` for in-flight moves.
+
+    On ``IObjectWillBeMovedEvent`` we record each object's current physical
+    path here, keyed by its ZODB ``_p_oid``.  On ``IObjectMovedEvent`` we pop
+    the entry and use it to call ``CatalogTool.moveObject``, which remaps the
+    catalog RID without a full unindex + reindex.
+
+    The map is stored via ``Transaction.set_data`` / ``Transaction.data`` —
+    rather than as a volatile ``_v_`` attribute directly on each object —
+    because volatile attributes are discarded whenever the ZODB object cache
+    evicts an object (ghostification).  For large subtrees (tens of thousands
+    of children) this caused the optimisation to silently fall back to a full
+    reindex for all objects ghostified between the ``IObjectWillBeMovedEvent``
+    and ``IObjectMovedEvent`` phases.  Transaction-attached data lives outside
+    the ZODB object graph, is never affected by cache pressure, and is
+    automatically discarded when the transaction commits or aborts.
+    """
+    txn = transaction.get()
+    try:
+        return txn.data(_MOVE_PATHS_KEY)
+    except KeyError:
+        registry = {}
+        txn.set_data(_MOVE_PATHS_KEY, registry)
+        return registry
+
+
 def get_context_aware_indexes():
     """Return frozenset of all context-aware catalog index names.
 
@@ -333,13 +375,10 @@ def handleContentishEvent(ob, event):
 
     elif IObjectMovedEvent.providedBy(event):
         if event.newParent is not None:
-            old_path = getattr(ob, '_v_cmf_old_path', None)
+            oid = getattr(ob, '_p_oid', None)
+            old_path = _pending_move_paths().pop(oid, None) if oid else None
             if old_path is not None:
                 # True move: optimization path — preserve catalog RID.
-                try:
-                    del ob._v_cmf_old_path
-                except AttributeError:
-                    pass
                 catalog = queryUtility(ICatalogTool)
                 if catalog is not None:
                     idxs = get_context_aware_indexes()
@@ -350,15 +389,22 @@ def handleContentishEvent(ob, event):
     elif IObjectWillBeMovedEvent.providedBy(event):
         if event.oldParent is not None:
             if event.newParent is not None:
-                # True move: check if optimization is available before
-                # deciding whether to skip the unindex.
+                # True move: record the current path so IObjectMovedEvent can
+                # call moveObject() to remap the catalog RID instead of doing
+                # a full unindex + reindex.  The path is stored in the
+                # transaction data dict (keyed by _p_oid) rather than as a
+                # volatile _v_ attribute on the object itself; volatile attrs
+                # are lost when ZODB ghostifies an object under cache pressure,
+                # which caused the optimisation to silently degrade for large
+                # subtrees.  See _pending_move_paths() for details.
                 catalog = queryUtility(ICatalogTool)
                 idxs = get_context_aware_indexes()
                 if catalog is not None and idxs:
-                    # Save old path; skip unindexObject so the catalog
-                    # entry survives for IObjectMovedEvent to remap.
-                    ob._v_cmf_old_path = '/'.join(ob.getPhysicalPath())
-                    return
+                    oid = getattr(ob, '_p_oid', None)
+                    if oid is not None:
+                        _pending_move_paths()[oid] = '/'.join(
+                            ob.getPhysicalPath())
+                        return  # skip unindexObject; catalog entry preserved
             ob.unindexObject()
 
     elif IObjectCopiedEvent.providedBy(event):

--- a/src/Products/CMFCore/CMFCatalogAware.py
+++ b/src/Products/CMFCore/CMFCatalogAware.py
@@ -14,8 +14,8 @@
 """
 
 import logging
-import transaction
 
+import transaction
 from AccessControl.class_init import InitializeClass
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from AccessControl.SecurityManagement import getSecurityManager

--- a/src/Products/CMFCore/CMFCatalogAware.py
+++ b/src/Products/CMFCore/CMFCatalogAware.py
@@ -312,7 +312,8 @@ class _BuiltinSecurityIndexProvider:
 
 
 class _MovePathsRegistryKey:
-    """Singleton used as key for ``transaction.set_data`` / ``transaction.data``.
+    """Singleton used as key for ``transaction.set_data`` /
+    ``transaction.data``.
 
     The ``transaction`` package stores arbitrary per-transaction data via
     ``Transaction.set_data(ob, value)`` / ``Transaction.data(ob)``, keyed by
@@ -326,7 +327,8 @@ _MOVE_PATHS_KEY = _MovePathsRegistryKey()
 
 
 def _pending_move_paths():
-    """Return the transaction-local dict ``{oid: old_path}`` for in-flight moves.
+    """Return the transaction-local dict ``{oid: old_path}`` for in-flight
+    moves.
 
     On ``IObjectWillBeMovedEvent`` we record each object's current physical
     path here, keyed by its ZODB ``_p_oid``.  On ``IObjectMovedEvent`` we pop

--- a/src/Products/CMFCore/CMFCatalogAware.py
+++ b/src/Products/CMFCore/CMFCatalogAware.py
@@ -23,6 +23,7 @@ from App.special_dtml import DTMLFile
 from ExtensionClass import Base
 from OFS.interfaces import IObjectClonedEvent
 from OFS.interfaces import IObjectWillBeMovedEvent
+from zope.component import getUtilitiesFor
 from zope.component import queryUtility
 from zope.component import subscribers
 from zope.interface import implementer
@@ -34,6 +35,7 @@ from zope.lifecycleevent.interfaces import IObjectMovedEvent
 from .interfaces import ICallableOpaqueItem
 from .interfaces import ICatalogAware
 from .interfaces import ICatalogTool
+from .interfaces import IContextAwareIndexProvider
 from .interfaces import IOpaqueItemManager
 from .interfaces import IWorkflowAware
 from .interfaces import IWorkflowTool
@@ -284,6 +286,42 @@ class CMFCatalogAware(CatalogAware, WorkflowAware, OpaqueItemManager):
     """
 
 
+@implementer(IContextAwareIndexProvider)
+class _BuiltinLocationIndexProvider:
+    """Default provider for location-based context-aware indexes.
+
+    These indexes change when an object moves to a different container
+    (its path and id change).
+    """
+
+    def getIndexNames(self):
+        return ('path', 'getId', 'id')
+
+
+@implementer(IContextAwareIndexProvider)
+class _BuiltinSecurityIndexProvider:
+    """Default provider for security context-aware indexes.
+
+    allowedRolesAndUsers must be recomputed whenever the object moves
+    into a differently-protected part of the tree.
+    """
+
+    def getIndexNames(self):
+        return ('allowedRolesAndUsers',)
+
+
+def get_context_aware_indexes():
+    """Return frozenset of all context-aware catalog index names.
+
+    Aggregates all named IContextAwareIndexProvider utilities.
+    Returns an empty frozenset if no providers are registered.
+    """
+    indexes = set()
+    for _name, provider in getUtilitiesFor(IContextAwareIndexProvider):
+        indexes.update(provider.getIndexNames())
+    return frozenset(indexes)
+
+
 def handleContentishEvent(ob, event):
     """ Event subscriber for (IContentish, IObjectEvent) events.
     """
@@ -295,10 +333,32 @@ def handleContentishEvent(ob, event):
 
     elif IObjectMovedEvent.providedBy(event):
         if event.newParent is not None:
+            old_path = getattr(ob, '_v_cmf_old_path', None)
+            if old_path is not None:
+                # True move: optimization path — preserve catalog RID.
+                try:
+                    del ob._v_cmf_old_path
+                except AttributeError:
+                    pass
+                catalog = queryUtility(ICatalogTool)
+                if catalog is not None:
+                    idxs = get_context_aware_indexes()
+                    catalog.moveObject(ob, old_path, idxs)
+                    return
             ob.indexObject()
 
     elif IObjectWillBeMovedEvent.providedBy(event):
         if event.oldParent is not None:
+            if event.newParent is not None:
+                # True move: check if optimization is available before
+                # deciding whether to skip the unindex.
+                catalog = queryUtility(ICatalogTool)
+                idxs = get_context_aware_indexes()
+                if catalog is not None and idxs:
+                    # Save old path; skip unindexObject so the catalog
+                    # entry survives for IObjectMovedEvent to remap.
+                    ob._v_cmf_old_path = '/'.join(ob.getPhysicalPath())
+                    return
             ob.unindexObject()
 
     elif IObjectCopiedEvent.providedBy(event):

--- a/src/Products/CMFCore/CMFCatalogAware.py
+++ b/src/Products/CMFCore/CMFCatalogAware.py
@@ -311,6 +311,51 @@ class _BuiltinSecurityIndexProvider:
         return ('allowedRolesAndUsers',)
 
 
+@implementer(IContextAwareIndexProvider)
+class _BuiltinModificationDateIndexProvider:
+    """Provider for the modification-date catalog indexes updated on every move.
+
+    ``handleContentishEvent`` calls ``ob.notifyModified()`` (when the method is
+    present) during the optimized move path, which updates the object's
+    modification date.  The catalog indexes ``modified`` and ``Date`` must
+    therefore be reindexed in the same ``moveObject`` call so the catalog entry
+    reflects the new date.
+
+    **Background — why notifyModified() is called at all on a move**
+
+    In a standard Plone installation (without the optimization) the call chain
+    on ``IObjectMovedEvent`` is::
+
+        handleContentishEvent
+          → ob.indexObject()
+          → CMFPlone.CatalogTool.indexObject(obj, idxs=[])  ← Plone override
+          → CMFCatalogAware.reindexObject(idxs=[])
+          → ob.notifyModified()                              ← side-effect
+
+    ``Products.CMFPlone`` overrides ``CatalogTool.indexObject`` to delegate to
+    ``reindexObject(idxs=[])``, and ``CMFCatalogAware.reindexObject`` calls
+    ``notifyModified()`` whenever ``idxs`` is empty.  The modification-date
+    update therefore happened as a side-effect of that override, not as an
+    intentional part of the move flow.
+
+    The optimization introduced in this branch bypasses ``indexObject``
+    entirely and calls ``catalog.moveObject()`` directly, which breaks the
+    side-effect chain.  ``handleContentishEvent`` compensates by calling
+    ``ob.notifyModified()`` explicitly, and this provider ensures the updated
+    date is written to the catalog in the same operation.
+
+    The semantic correctness of updating the modification date on a move is
+    well-established: HTTP caches and ETags that are built on modification
+    dates must be invalidated when an object's canonical URL changes, even if
+    its content has not changed.  This is also the rationale documented by
+    ``ftw.copymovepatches``, a third-party package that adds the same
+    behaviour to older CMFCore versions.
+    """
+
+    def getIndexNames(self):
+        return ('modified', 'Date')
+
+
 class _MovePathsRegistryKey:
     """Singleton used as key for ``transaction.set_data`` /
     ``transaction.data``.
@@ -383,6 +428,16 @@ def handleContentishEvent(ob, event):
                 # True move: optimization path — preserve catalog RID.
                 catalog = queryUtility(ICatalogTool)
                 if catalog is not None:
+                    # Update the modification date before writing the catalog
+                    # entry.  In the non-optimized path this happened as a
+                    # side-effect of CMFPlone overriding CatalogTool.indexObject
+                    # to call reindexObject(idxs=[]), which in turn calls
+                    # notifyModified().  Our optimization bypasses that chain,
+                    # so we call notifyModified() explicitly here.
+                    # See _BuiltinModificationDateIndexProvider for the full
+                    # rationale and background.
+                    if hasattr(aq_base(ob), 'notifyModified'):
+                        ob.notifyModified()
                     idxs = get_context_aware_indexes()
                     catalog.moveObject(ob, old_path, idxs)
                     return

--- a/src/Products/CMFCore/CatalogTool.py
+++ b/src/Products/CMFCore/CatalogTool.py
@@ -344,6 +344,34 @@ class CatalogTool(UniqueObject, ZCatalog, ActionProviderBase):
             )
 
     @security.private
+    def moveObject(self, object, old_path, idxs):
+        """Update the catalog when 'object' is moved, preserving its RID.
+
+        Flushes the index queue to ensure the catalog is consistent, then
+        remaps the old path to the same RID at the new path in the
+        underlying catalog, and reindexes 'idxs'.
+        """
+        getQueue().process()
+
+        new_path = '/'.join(object.getPhysicalPath())
+        cat = self._catalog
+        rid = cat.uids.get(old_path)
+
+        if rid is None:
+            # Object not in catalog (e.g., added and moved in same
+            # transaction; INDEX already ran at new_path via queue.process).
+            self.reindexObject(object, idxs=list(idxs), update_metadata=1)
+            return
+
+        # Remap old path → same RID → new path (preserves RID)
+        cat.uids[new_path] = rid
+        cat.paths[rid] = new_path
+        if old_path in cat.uids:
+            del cat.uids[old_path]
+
+        self.reindexObject(object, idxs=list(idxs), update_metadata=1)
+
+    @security.private
     def _indexObject(self, object):
         """Add to catalog.
         """

--- a/src/Products/CMFCore/content.zcml
+++ b/src/Products/CMFCore/content.zcml
@@ -46,6 +46,17 @@
     name="portal-catalog"
     factory="Products.CMFCore.indexing.PortalCatalogProcessor" />
 
+  <!-- Context-aware index providers for move optimization -->
+  <utility
+    provides="Products.CMFCore.interfaces.IContextAwareIndexProvider"
+    name="cmf.location"
+    factory="Products.CMFCore.CMFCatalogAware._BuiltinLocationIndexProvider" />
+
+  <utility
+    provides="Products.CMFCore.interfaces.IContextAwareIndexProvider"
+    name="cmf.security"
+    factory="Products.CMFCore.CMFCatalogAware._BuiltinSecurityIndexProvider" />
+
   <!-- Don't publish acquired content items  -->
   <adapter
       provides=".interfaces.IShouldAllowAcquiredItemPublication"

--- a/src/Products/CMFCore/content.zcml
+++ b/src/Products/CMFCore/content.zcml
@@ -57,6 +57,11 @@
     name="cmf.security"
     factory="Products.CMFCore.CMFCatalogAware._BuiltinSecurityIndexProvider" />
 
+  <utility
+    provides="Products.CMFCore.interfaces.IContextAwareIndexProvider"
+    name="cmf.modification-date"
+    factory="Products.CMFCore.CMFCatalogAware._BuiltinModificationDateIndexProvider" />
+
   <!-- Don't publish acquired content items  -->
   <adapter
       provides=".interfaces.IShouldAllowAcquiredItemPublication"

--- a/src/Products/CMFCore/interfaces/_tools.py
+++ b/src/Products/CMFCore/interfaces/_tools.py
@@ -411,6 +411,17 @@ class ICatalogTool(Interface):
         o Permission:  Private (Python only)
         """
 
+    def moveObject(object, old_path, idxs):
+        """Update the catalog when 'object' is moved, preserving its RID.
+
+        Flushes the index queue, remaps the old path to the same RID at
+        the new path in the underlying catalog, then reindexes 'idxs'.
+
+        o 'old_path' is the physical path string before the move.
+        o 'idxs' is the collection of context-aware index names to reindex.
+        o Permission:  Private (Python only)
+        """
+
 
 class IIndexableObjectWrapper(Interface):
 
@@ -2253,6 +2264,31 @@ class IIndexQueueProcessor(IIndexing):
 class IPortalCatalogQueueProcessor(IIndexQueueProcessor):
     """ an index queue processor for the standard portal catalog via
         the `CatalogMultiplex` and `CMFCatalogAware` mixin classes """
+
+
+class IContextAwareIndexProvider(Interface):
+    """Named utility contributing catalog index names that must be
+    reindexed when an object moves within the content tree.
+
+    Register a named utility providing this interface to add custom
+    location- or security-sensitive indexes.  Use your package's dotted
+    name as the utility name (e.g. ``"mypackage.myindex"``) to avoid
+    conflicts.  All registered providers are aggregated by
+    ``CMFCatalogAware.get_context_aware_indexes()``.
+    """
+
+    __module__ = 'Products.CMFCore.interfaces'
+
+    def getIndexNames():
+        """Return a sequence of context-aware catalog index names.
+
+        These are indexes whose values change when an object moves to a
+        different location in the content tree (path, id, security context,
+        etc.).
+
+        o Return a sequence (tuple or list) of strings.
+        o Permission: Private (Python only)
+        """
 
 
 class InvalidQueueOperation(Exception):

--- a/src/Products/CMFCore/tests/test_CMFCatalogAware.py
+++ b/src/Products/CMFCore/tests/test_CMFCatalogAware.py
@@ -106,7 +106,7 @@ class DummyCatalog(SimpleItem):
 
     def moveObject(self, ob, old_path, idxs):
         self.log.append(
-            'move %s from %s %s' % (
+            'move {} from {} {}'.format(
                 physicalpath(ob), old_path, sorted(idxs)))
 
     def setObs(self, obs):

--- a/src/Products/CMFCore/tests/test_CMFCatalogAware.py
+++ b/src/Products/CMFCore/tests/test_CMFCatalogAware.py
@@ -379,7 +379,8 @@ class CMFCatalogAware_CopySupport_Tests(SecurityTest):
 
 
 class ContextAwareIndexProviderTests(unittest.TestCase):
-    """Tests for IContextAwareIndexProvider utilities and get_context_aware_indexes."""
+    """Tests for IContextAwareIndexProvider utilities and the
+    get_context_aware_indexes helper."""
 
     def setUp(self):
         self._sm = getSiteManager()

--- a/src/Products/CMFCore/tests/test_CMFCatalogAware.py
+++ b/src/Products/CMFCore/tests/test_CMFCatalogAware.py
@@ -24,9 +24,13 @@ from zope.component import getSiteManager
 from zope.interface import implementer
 
 from ..CMFCatalogAware import CMFCatalogAware
+from ..CMFCatalogAware import _BuiltinLocationIndexProvider
+from ..CMFCatalogAware import _BuiltinSecurityIndexProvider
+from ..CMFCatalogAware import get_context_aware_indexes
 from ..exceptions import NotFound
 from ..interfaces import ICatalogTool
 from ..interfaces import IContentish
+from ..interfaces import IContextAwareIndexProvider
 from ..interfaces import IWorkflowTool
 from ..testing import EventZCMLLayer
 from ..testing import TraversingZCMLLayer
@@ -99,6 +103,11 @@ class DummyCatalog(SimpleItem):
 
     def unindexObject(self, ob):
         self.log.append('unindex %s' % physicalpath(ob))
+
+    def moveObject(self, ob, old_path, idxs):
+        self.log.append(
+            'move %s from %s %s' % (
+                physicalpath(ob), old_path, sorted(idxs)))
 
     def setObs(self, obs):
         self.obs = [(ob, physicalpath(ob)) for ob in obs]
@@ -369,9 +378,171 @@ class CMFCatalogAware_CopySupport_Tests(SecurityTest):
         self.assertEqual(cat.log, ['unindex /site/bar', 'index /site/baz'])
 
 
+class ContextAwareIndexProviderTests(unittest.TestCase):
+    """Tests for IContextAwareIndexProvider utilities and get_context_aware_indexes."""
+
+    def setUp(self):
+        self._sm = getSiteManager()
+
+    def tearDown(self):
+        for name, _ in list(
+                self._sm.getUtilitiesFor(IContextAwareIndexProvider)):
+            self._sm.unregisterUtility(
+                provided=IContextAwareIndexProvider, name=name)
+
+    def test_location_provider(self):
+        names = _BuiltinLocationIndexProvider().getIndexNames()
+        self.assertIn('path', names)
+        self.assertIn('getId', names)
+        self.assertIn('id', names)
+
+    def test_security_provider(self):
+        names = _BuiltinSecurityIndexProvider().getIndexNames()
+        self.assertIn('allowedRolesAndUsers', names)
+
+    def test_get_context_aware_indexes_no_providers(self):
+        result = get_context_aware_indexes()
+        self.assertEqual(result, frozenset())
+
+    def test_get_context_aware_indexes_with_defaults(self):
+        self._sm.registerUtility(
+            _BuiltinLocationIndexProvider(),
+            IContextAwareIndexProvider,
+            name='cmf.location',
+        )
+        self._sm.registerUtility(
+            _BuiltinSecurityIndexProvider(),
+            IContextAwareIndexProvider,
+            name='cmf.security',
+        )
+        result = get_context_aware_indexes()
+        self.assertIn('path', result)
+        self.assertIn('getId', result)
+        self.assertIn('id', result)
+        self.assertIn('allowedRolesAndUsers', result)
+
+    def test_get_context_aware_indexes_third_party(self):
+        @implementer(IContextAwareIndexProvider)
+        class CustomProvider:
+            def getIndexNames(self):
+                return ('my_custom_index',)
+
+        self._sm.registerUtility(
+            _BuiltinLocationIndexProvider(),
+            IContextAwareIndexProvider,
+            name='cmf.location',
+        )
+        self._sm.registerUtility(
+            CustomProvider(),
+            IContextAwareIndexProvider,
+            name='test.custom',
+        )
+        result = get_context_aware_indexes()
+        self.assertIn('my_custom_index', result)
+        self.assertIn('path', result)
+
+    def test_get_context_aware_indexes_deduplication(self):
+        @implementer(IContextAwareIndexProvider)
+        class DuplicateProvider:
+            def getIndexNames(self):
+                return ('allowedRolesAndUsers',)
+
+        self._sm.registerUtility(
+            _BuiltinSecurityIndexProvider(),
+            IContextAwareIndexProvider,
+            name='cmf.security',
+        )
+        self._sm.registerUtility(
+            DuplicateProvider(),
+            IContextAwareIndexProvider,
+            name='test.duplicate',
+        )
+        result = get_context_aware_indexes()
+        self.assertEqual(
+            len([n for n in result if n == 'allowedRolesAndUsers']), 1)
+
+
+class CMFCatalogAwareMoveOptimizationTests(CMFCatalogAware_CopySupport_Tests):
+    """Re-run the copy-support suite with IContextAwareIndexProvider
+    utilities registered.
+
+    With providers registered, true moves take the optimized ``moveObject``
+    path (only context-aware indexes are reindexed, RID preserved), while
+    add / remove / copy behavior is unchanged.  The two move tests are
+    overridden to assert the optimized behavior; all other inherited tests
+    verify the non-move paths are unaffected.
+    """
+
+    def setUp(self):
+        super().setUp()
+        sm = getSiteManager()
+        sm.registerUtility(
+            _BuiltinLocationIndexProvider(),
+            IContextAwareIndexProvider,
+            name='cmf.location',
+        )
+        sm.registerUtility(
+            _BuiltinSecurityIndexProvider(),
+            IContextAwareIndexProvider,
+            name='cmf.security',
+        )
+
+    def tearDown(self):
+        sm = getSiteManager()
+        sm.unregisterUtility(
+            provided=IContextAwareIndexProvider, name='cmf.location')
+        sm.unregisterUtility(
+            provided=IContextAwareIndexProvider, name='cmf.security')
+        super().tearDown()
+
+    def test_object_reindexed_after_cut_and_paste(self):
+        self._initPolicyAndUser()  # allow copy/paste operations
+        site = self._makeSite()
+        site.folder1 = SimpleFolder('folder1')
+        folder1 = site.folder1
+        site.folder2 = SimpleFolder('folder2')
+        folder2 = site.folder2
+
+        bar = TheClass('bar')
+        folder1._setObject('bar', bar)
+        cat = self.ctool
+        cat.log = []
+
+        transaction.savepoint(optimistic=True)
+
+        cookie = folder1.manage_cutObjects(ids=['bar'])
+        folder2.manage_pasteObjects(cookie)
+
+        idxs = sorted(get_context_aware_indexes())
+        self.assertEqual(
+            cat.log,
+            ['move /site/folder2/bar from /site/folder1/bar %s' % idxs])
+
+    def test_object_reindexed_after_moving(self):
+        self._initPolicyAndUser()  # allow copy/paste operations
+        site = self._makeSite()
+
+        bar = TheClass('bar')
+        site._setObject('bar', bar)
+        cat = self.ctool
+        cat.log = []
+
+        transaction.savepoint(optimistic=True)
+
+        site.manage_renameObject(id='bar', new_id='baz')
+
+        idxs = sorted(get_context_aware_indexes())
+        self.assertEqual(
+            cat.log, ['move /site/baz from /site/bar %s' % idxs])
+
+
 def test_suite():
     return unittest.TestSuite((
         unittest.defaultTestLoader.loadTestsFromTestCase(CMFCatalogAwareTests),
         unittest.defaultTestLoader.loadTestsFromTestCase(
             CMFCatalogAware_CopySupport_Tests),
+        unittest.defaultTestLoader.loadTestsFromTestCase(
+            ContextAwareIndexProviderTests),
+        unittest.defaultTestLoader.loadTestsFromTestCase(
+            CMFCatalogAwareMoveOptimizationTests),
     ))

--- a/src/Products/CMFCore/tests/test_CMFCatalogAware.py
+++ b/src/Products/CMFCore/tests/test_CMFCatalogAware.py
@@ -553,7 +553,8 @@ class CMFCatalogAwareMoveOptimizationTests(CMFCatalogAware_CopySupport_Tests):
         # The optimized move path must call ob.notifyModified() so that the
         # modification date is updated in the same operation.  In the
         # non-optimized Plone path this happened as a side-effect of
-        # CMFPlone.CatalogTool.indexObject delegating to reindexObject(idxs=[]).
+        # CMFPlone.CatalogTool.indexObject delegating to
+        # reindexObject(idxs=[]).
         self._initPolicyAndUser()
         site = self._makeSite()
         site.folder1 = SimpleFolder('folder1')
@@ -582,8 +583,9 @@ class CMFCatalogAwareMoveOptimizationTests(CMFCatalogAware_CopySupport_Tests):
 
         site.manage_renameObject(id='bar', new_id='baz')
 
-        self.assertTrue(site['baz'].notified,
-                        'notifyModified() was not called on the renamed object')
+        self.assertTrue(
+            site['baz'].notified,
+            'notifyModified() was not called on the renamed object')
 
 
 def test_suite():

--- a/src/Products/CMFCore/tests/test_CMFCatalogAware.py
+++ b/src/Products/CMFCore/tests/test_CMFCatalogAware.py
@@ -25,6 +25,7 @@ from zope.interface import implementer
 
 from ..CMFCatalogAware import CMFCatalogAware
 from ..CMFCatalogAware import _BuiltinLocationIndexProvider
+from ..CMFCatalogAware import _BuiltinModificationDateIndexProvider
 from ..CMFCatalogAware import _BuiltinSecurityIndexProvider
 from ..CMFCatalogAware import get_context_aware_indexes
 from ..exceptions import NotFound
@@ -401,6 +402,11 @@ class ContextAwareIndexProviderTests(unittest.TestCase):
         names = _BuiltinSecurityIndexProvider().getIndexNames()
         self.assertIn('allowedRolesAndUsers', names)
 
+    def test_modification_date_provider(self):
+        names = _BuiltinModificationDateIndexProvider().getIndexNames()
+        self.assertIn('modified', names)
+        self.assertIn('Date', names)
+
     def test_get_context_aware_indexes_no_providers(self):
         result = get_context_aware_indexes()
         self.assertEqual(result, frozenset())
@@ -487,6 +493,11 @@ class CMFCatalogAwareMoveOptimizationTests(CMFCatalogAware_CopySupport_Tests):
             IContextAwareIndexProvider,
             name='cmf.security',
         )
+        sm.registerUtility(
+            _BuiltinModificationDateIndexProvider(),
+            IContextAwareIndexProvider,
+            name='cmf.modification-date',
+        )
 
     def tearDown(self):
         sm = getSiteManager()
@@ -494,6 +505,8 @@ class CMFCatalogAwareMoveOptimizationTests(CMFCatalogAware_CopySupport_Tests):
             provided=IContextAwareIndexProvider, name='cmf.location')
         sm.unregisterUtility(
             provided=IContextAwareIndexProvider, name='cmf.security')
+        sm.unregisterUtility(
+            provided=IContextAwareIndexProvider, name='cmf.modification-date')
         super().tearDown()
 
     def test_object_reindexed_after_cut_and_paste(self):
@@ -535,6 +548,42 @@ class CMFCatalogAwareMoveOptimizationTests(CMFCatalogAware_CopySupport_Tests):
         idxs = sorted(get_context_aware_indexes())
         self.assertEqual(
             cat.log, ['move /site/baz from /site/bar %s' % idxs])
+
+    def test_notifyModified_called_after_cut_and_paste(self):
+        # The optimized move path must call ob.notifyModified() so that the
+        # modification date is updated in the same operation.  In the
+        # non-optimized Plone path this happened as a side-effect of
+        # CMFPlone.CatalogTool.indexObject delegating to reindexObject(idxs=[]).
+        self._initPolicyAndUser()
+        site = self._makeSite()
+        site.folder1 = SimpleFolder('folder1')
+        folder1 = site.folder1
+        site.folder2 = SimpleFolder('folder2')
+        folder2 = site.folder2
+
+        bar = TheClass('bar')
+        folder1._setObject('bar', bar)
+        transaction.savepoint(optimistic=True)
+
+        cookie = folder1.manage_cutObjects(ids=['bar'])
+        folder2.manage_pasteObjects(cookie)
+
+        self.assertTrue(folder2['bar'].notified,
+                        'notifyModified() was not called on the moved object')
+
+    def test_notifyModified_called_after_moving(self):
+        # Same as above for rename (manage_renameObject).
+        self._initPolicyAndUser()
+        site = self._makeSite()
+
+        bar = TheClass('bar')
+        site._setObject('bar', bar)
+        transaction.savepoint(optimistic=True)
+
+        site.manage_renameObject(id='bar', new_id='baz')
+
+        self.assertTrue(site['baz'].notified,
+                        'notifyModified() was not called on the renamed object')
 
 
 def test_suite():


### PR DESCRIPTION
- Optimize object moves by reindexing only context-aware indexes instead of a full unindex + reindex.  The catalog RID is preserved across the move, avoiding stale references and unnecessary work. A new ``moveObject(object, old_path, idxs)`` method is added to ``CatalogTool`` and ``ICatalogTool`` to implement the path remap.

- Add ``IContextAwareIndexProvider``, a named-utility interface that  contributes catalog index names which must be reindexed on object moves  (path-sensitive, security-sensitive, etc.).  Register a named utility  providing this interface to extend the default set (``path``, ``getId``,  ``id``, ``allowedRolesAndUsers``).  The helper ``CMFCatalogAware.get_context_aware_indexes()`` aggregates all registered  providers.

**Based on / inspirated by:** 

1. https://github.com/plone/Products.CMFPlone/pull/3834#issuecomment-4091153715
2. https://github.com/4teamwork/ftw.copymovepatches


- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [ ] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [ ] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added documentation for my changes.
- [x] I included a change log entry in my commits.


